### PR TITLE
Fix some issues with fullscreen toggleing and add default file output resolution

### DIFF
--- a/apps/qtViewer/ModelViewer.cpp
+++ b/apps/qtViewer/ModelViewer.cpp
@@ -153,20 +153,11 @@ namespace ospray {
     void ModelViewer::createEditorWidgetStack()
     {
       editorWidgetStack = new EditorWidgetStack;
-      // editorWidgetStack->addPage("Test1",new QLabel("Test1"));
-      // editorWidgetStack->addPage("Test2",new QLabel("Test2"));
-      QDockWidget *dock = new QDockWidget(this);
-      // dock->setWindowTitle("Editors");
-      // dock->setWidget(editorWidgetStack);
-      // dock->setFeatures(0);
-      // addDockWidget(Qt::RightDockWidgetArea,dock);
-
       editorWidgetDock = new QDockWidget(this);
       editorWidgetDock->setWindowTitle("Editors");
       editorWidgetDock->setWidget(editorWidgetStack);
       editorWidgetDock->setFeatures(0);
       addDockWidget(Qt::RightDockWidgetArea,editorWidgetDock);
-
     }
 
     void ModelViewer::createTransferFunctionEditor()
@@ -259,18 +250,16 @@ namespace ospray {
       setWindowTitle(tr("OSPRay QT ModelViewer"));
       resize(1024,768);
 
-      if (!fullscreen){
-        // create GUI elements
-        toolBar = addToolBar("toolbar");
+      // create GUI elements
+      toolBar = addToolBar("toolbar");
 
-        QAction *printCameraAction = new QAction("Print Camera", this);
-        connect(printCameraAction, SIGNAL(triggered()), this, SLOT(printCameraAction()));
-        toolBar->addAction(printCameraAction);
+      QAction *printCameraAction = new QAction("Print Camera", this);
+      connect(printCameraAction, SIGNAL(triggered()), this, SLOT(printCameraAction()));
+      toolBar->addAction(printCameraAction);
 
-        QAction *screenShotAction = new QAction("Screenshot", this);
-        connect(screenShotAction, SIGNAL(triggered()), this, SLOT(screenShotAction()));
-        toolBar->addAction(screenShotAction);
-      }
+      QAction *screenShotAction = new QAction("Screenshot", this);
+      connect(screenShotAction, SIGNAL(triggered()), this, SLOT(screenShotAction()));
+      toolBar->addAction(screenShotAction);
 
       renderWidget = new OSPRayRenderWidget(sgRenderer);
       ///renderWidget = new CheckeredSphereRotationEditor();

--- a/apps/qtViewer/main.cpp
+++ b/apps/qtViewer/main.cpp
@@ -192,8 +192,9 @@ namespace ospray {
         ModelViewer *modelViewer = new ModelViewer(renderer, fullscreen);
         // modelViewer->setFixedSize(frameResolution.x,frameResolution.y);
         modelViewer->showFrameRate(showFPS);
+        std::cout << "#osp:qtv: Press 'f' to toggle fullscreen rendering mode" << endl;
         if (fullscreen){
-          std::cout << "#osp:qtv: ppening fullscreen viewer, press 'ESC' to quit\n";
+          std::cout << "#osp:qtv: opening fullscreen viewer, press 'ESC' to quit" << endl;
           modelViewer->showFullScreen();
         } else {
           modelViewer->show();

--- a/apps/qtViewer/main.cpp
+++ b/apps/qtViewer/main.cpp
@@ -219,6 +219,10 @@ namespace ospray {
         delete app;
       } else {
         cout << "#osp:qtv: setting up in render-to-file mode" << endl;
+        if (frameResolution == vec2i(-1, -1)) {
+          cout << "#osp:qtv: Warning! no resolution specified, defaulting to 1280x720" << endl;
+          frameResolution = vec2i(1280, 720);
+        }
         if (!renderer->frameBuffer) {
           cout << "#osp:qtv: creating default framebuffer (" 
                << frameResolution.x << "x" << frameResolution.y << ")" << endl;


### PR DESCRIPTION
Hey Greg, Ingo,

This fixes some changes that got lost for adding the fullscreen toggle option to the qtViewer, since the diff didn't apply automatically. Previously an extra dock would be created and so in the fullscreen mode you'd have this odd black rectangle in the top-left, the docks should now be configured properly. I also added a default render to file resolution (1280x720) as we crash otherwise since the default is (-1, -1), we also print a warning if no resolution was specified.

I think I should match the tabs/spacing convention used in the code (mismatch is why the diff failed iirc), but let me know if some stuff should be tweaked :)