### PR TITLE
Added an option to disable building of apps.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,9 +120,12 @@ ENDIF()
 ##############################################################
 # ospray sample apps at the end, they may need modules
 ##############################################################
-SET (OSPRAY_TARGET "intel64")
-ADD_SUBDIRECTORY(apps builddir/apps/intel64)
-IF (OSPRAY_MIC)
-  SET (OSPRAY_TARGET "mic")
-  ADD_SUBDIRECTORY(apps builddir/apps/mic)
+OPTION(OSPRAY_BUILD_APPS "Enable building of sample apps." ON)
+IF(OSPRAY_BUILD_APPS)
+  SET (OSPRAY_TARGET "intel64")
+  ADD_SUBDIRECTORY(apps builddir/apps/intel64)
+  IF (OSPRAY_MIC)
+    SET (OSPRAY_TARGET "mic")
+    ADD_SUBDIRECTORY(apps builddir/apps/mic)
+  ENDIF()
 ENDIF()


### PR DESCRIPTION
Making building of apps optional.

This makes it easier to build ospray for packaging in ParaView binaries.