### PR TITLE
Arguments to init function can be NULL

### DIFF
--- a/ospray/common/OSPCommon.cpp
+++ b/ospray/common/OSPCommon.cpp
@@ -106,6 +106,9 @@ namespace ospray {
       throw std::runtime_error("Error. OSPRay only runs on CPUs that support at least SSE4.1.");
 #endif
 
+    if (!_ac || !_av)
+      return;
+
     int &ac = *_ac;
     char ** &av = *(char ***)_av;
     for (int i=1;i<ac;) {


### PR DESCRIPTION
This fixes the bug when there are no argc and argv present and passing dummy variables does not make sense and is clunky.