### PR TITLE
Enable client-side searching for doxygen

### DIFF
--- a/doc/dox/doxyconfig.in
+++ b/doc/dox/doxyconfig.in
@@ -1077,7 +1077,7 @@ FORMULA_FONTSIZE       = 10
 # typically be disabled. For large projects the javascript based search engine
 # can be slow, then enabling SERVER_BASED_SEARCH may provide a better solution.
 
-SEARCHENGINE           = NO
+SEARCHENGINE           = YES
 
 # When the SERVER_BASED_SEARCH tag is enabled the search engine will be
 # implemented using a PHP enabled web server instead of at the web client
@@ -1087,7 +1087,7 @@ SEARCHENGINE           = NO
 # full text search. The disadvantages are that it is more difficult to setup
 # and does not have live searching capabilities.
 
-#SERVER_BASED_SEARCH    = NO
+SERVER_BASED_SEARCH    = NO
 
 #---------------------------------------------------------------------------
 # configuration options related to the LaTeX output


### PR DESCRIPTION
It's tough to find things in the documentation without a search feature if you don't already know what you're looking for. Doxygen has a client-side search feature that this commit enables so you can search the local build of the documentation without needing a server. It can be a bit slow (since the project is large) but is better than no search feature.

I wasn't sure if I should open this PR to master or devel, since it's such a small non-code change, let me know if I should re-open it against devel.