### PR TITLE
Fix crash for distributed rendering when using BatchedIsendIrecv

### DIFF
--- a/ospray/mpi/async/BatchedIsendIrecvMessaging.cpp
+++ b/ospray/mpi/async/BatchedIsendIrecvMessaging.cpp
@@ -38,10 +38,10 @@ namespace ospray {
       {
         Group  *g = this->group;
         Action *actions[SEND_WINDOW_SIZE];
+        MPI_Request request[SEND_WINDOW_SIZE];
         while (1) {
           // usleep(80);
           size_t numActions = g->sendQueue.getSome(actions,SEND_WINDOW_SIZE);
-          auto *request = (MPI_Request*)alloca(numActions*sizeof(MPI_Request));
           for (int i=0;i<numActions;i++) {
             Action *action = actions[i];
             MPI_CALL(Isend(action->data,action->size,MPI_BYTE,


### PR DESCRIPTION
Memory allocated with `alloca` doesn't get free'd until the function scope exits, at least from how the [man page reads](http://man7.org/linux/man-pages/man3/alloca.3.html). So re-calling `alloca` in the while loop will keep growing the stack until eventually we overflow the stack and crash.

Similar to the RecvThread we now just put a constant `SEND_WINDOW_SIZE` size array of `MPI_Request` on the stack up front and use that.

I thought I tried not using `alloca` previously and it still crashed, but I must have introduced some other issue or am mis-remembering what I tried. This seems stable now, I've left it running on Maverick (1 node w/ 3 procs) built with the Intel toolchain for ~20 min and for a similar time frame on my desktop with GCC & OpenMPI without crashing. Let me know how it looks on the internal cluster, I'll also test on an actually distributed set up tomorrow.