### PR TITLE
Volume data can have different resolution for different regions

### DIFF
--- a/apps/qtViewer/sg/volume/Volume.cpp
+++ b/apps/qtViewer/sg/volume/Volume.cpp
@@ -94,6 +94,7 @@ namespace ospray {
         vec3i region_lo(0,0,z), region_sz(dimensions.x,dimensions.y,1);
         ospSetRegion(volume,slice,
                      (const osp::vec3i&)region_lo,
+                     (const osp::vec3i&)region_sz,
                      (const osp::vec3i&)region_sz);
       }
 
@@ -189,7 +190,10 @@ namespace ospray {
             if (nRead != nPerSlice)
               throw std::runtime_error("StructuredVolume::render(): read incomplete slice data ... partial file or wrong format!?");
             const vec3i region_lo(0,0,z),region_sz(dimensions.x,dimensions.y,1);
-            ospSetRegion(volume,slice,(const osp::vec3i&)region_lo,(const osp::vec3i&)region_sz);
+            ospSetRegion(volume,slice,
+                         (const osp::vec3i&)region_lo,
+                         (const osp::vec3i&)region_sz,
+                         (const osp::vec3i&)region_sz);
           }
           delete[] slice;
         } else {
@@ -201,6 +205,7 @@ namespace ospray {
             const vec3i region_lo(0,0,z), region_sz(dimensions.x,dimensions.y,1);
             ospSetRegion(volume,slice,
                          (const osp::vec3i&)region_lo,
+                         (const osp::vec3i&)region_sz,
                          (const osp::vec3i&)region_sz);
           }
           delete[] slice;
@@ -295,6 +300,7 @@ namespace ospray {
         const vec3i region_lo(0,0,sliceID), region_sz(dimensions.x,dimensions.y,1);
         ospSetRegion(volume,slice,
                      (const osp::vec3i&)region_lo,
+                     (const osp::vec3i&)region_sz,
                      (const osp::vec3i&)region_sz);
         fclose(file);
       }

--- a/modules/loaders/RMVolumeFile.cpp
+++ b/modules/loaders/RMVolumeFile.cpp
@@ -142,7 +142,10 @@ struct RMLoaderThreads {
 #endif
       ospray::vec3i region_lo(I*256,J*256,K*128);
       ospray::vec3i region_sz(256,256,128);
-      ospSetRegion(volume,block->voxel,(osp::vec3i&)region_lo,(osp::vec3i&)region_sz);
+      ospSetRegion(volume,block->voxel,
+                   (osp::vec3i&)region_lo,
+                   (osp::vec3i&)region_sz,
+                   (osp::vec3i&)region_sz);
       mutex.unlock();
       
       ospray::vec2f blockRange(block->voxel[0]);

--- a/modules/loaders/RawVolumeFile.cpp
+++ b/modules/loaders/RawVolumeFile.cpp
@@ -180,6 +180,7 @@ ospray::vec2f voxelRange(+std::numeric_limits<float>::infinity(),
       ospSetRegion(volume,
                    voxelData,
                    (osp::vec3i&)region_lo,
+                   (osp::vec3i&)region_sz,
                    (osp::vec3i&)region_sz);
 
       std::cerr << "volume load: "
@@ -244,6 +245,7 @@ ospray::vec2f voxelRange(+std::numeric_limits<float>::infinity(),
         ospSetRegion(volume,
                      &subvolumeRowData[0],
                      (osp::vec3i&)region_lo,
+                     (osp::vec3i&)region_sz,
                      (osp::vec3i&)region_sz);
       }
     }

--- a/modules/seismic/SeismicVolumeFile.cpp
+++ b/modules/seismic/SeismicVolumeFile.cpp
@@ -268,6 +268,7 @@ bool SeismicVolumeFile::importVoxelData(OSPVolume volume) {
       ospray::vec3i regionSize(volumeDimensions.x, 1, 1);
       ospSetRegion(volume, &traceBuffer[traceHeaderSize],
                    (const osp::vec3i &)regionCoords,
+                   (const osp::vec3i &)regionSize,
                    (const osp::vec3i &)regionSize);
 
       traceCount++;

--- a/ospray/api/API.cpp
+++ b/ospray/api/API.cpp
@@ -523,10 +523,12 @@ namespace ospray {
   /*! Copy data into the given volume. */
   extern "C" int ospSetRegion(OSPVolume object, void *source,
                               const osp::vec3i &index,
-                              const osp::vec3i &count)
+                              const osp::vec3i &count,
+                              const osp::vec3i &region)
   {
     ASSERT_DEVICE();
-    return(ospray::api::Device::current->setRegion(object, source, (const vec3i&)index, (const vec3i&)count));
+    return(ospray::api::Device::current->setRegion(object, source, (const vec3i&)index,
+                                                   (const vec3i&)count, (const vec3i&)region ));
   }
 
   /*! add a vec2f parameter to an object */

--- a/ospray/api/COIDeviceHost.cpp
+++ b/ospray/api/COIDeviceHost.cpp
@@ -216,7 +216,7 @@ namespace ospray {
 
       /*! Copy data into the given volume. */
       int setRegion(OSPVolume object, const void *source,
-                    const vec3i &index, const vec3i &count) override;
+                    const vec3i &index, const vec3i &count, const Vec3i &region ) override;
 
       /*! create a new pixelOp object (out of list of registered pixelOps) */
       OSPPixelOp newPixelOp(const char *type) override { NOTIMPLEMENTED; }
@@ -1182,7 +1182,8 @@ namespace ospray {
 
     /*! Copy data into the given volume. */
     int COIDevice::setRegion(OSPVolume object, const void *source, 
-                             const vec3i &index, const vec3i &count) 
+                             const vec3i &index, const vec3i &count,
+                             const vec3i &region )
     {
       Assert(object != nullptr && "invalid volume object handle");
       char *typeString = nullptr;
@@ -1198,6 +1199,7 @@ namespace ospray {
       stream.write((ObjectHandle &) data);
       stream.write(index);
       stream.write(count);
+      stream.write(region);
       callFunction(OSPCOI_SET_REGION, stream, &result, sizeof(int));
 //    release(data);
       return(result);

--- a/ospray/api/COIDeviceWorker.cpp
+++ b/ospray/api/COIDeviceWorker.cpp
@@ -753,8 +753,9 @@ namespace ospray {
       Data *data  = (Data *) stream.get<ObjectHandle>().lookup();
       vec3i index = stream.get<vec3i>();
       vec3i count = stream.get<vec3i>();
+      vec3i region = stream.get<vec3i>();
       int *result = (int *) retVal;
-      result[0] = volume->setRegion(data->data, index, count);
+      result[0] = volume->setRegion(data->data, index, count, region);
 
     }
 

--- a/ospray/api/Device.h
+++ b/ospray/api/Device.h
@@ -75,7 +75,7 @@ namespace ospray {
 
       /*! Copy data into the given volume. */
       virtual int setRegion(OSPVolume object, const void *source, 
-                            const vec3i &index, const vec3i &count) = 0;
+                            const vec3i &index, const vec3i &count, const vec3i &region) = 0;
 
       /*! assign (named) string parameter to an object */
       virtual void setString(OSPObject object, const char *bufName, const char *s) = 0;

--- a/ospray/api/LocalDevice.cpp
+++ b/ospray/api/LocalDevice.cpp
@@ -277,11 +277,12 @@ namespace ospray {
 
     /*! Copy data into the given volume. */
     int LocalDevice::setRegion(OSPVolume handle, const void *source,
-                               const vec3i &index, const vec3i &count)
+                               const vec3i &index, const vec3i &count,
+                               const vec3i &region)
     {
       Volume *volume = (Volume *) handle;
       Assert(volume != NULL && "invalid volume object handle");
-      return(volume->setRegion(source, index, count));
+      return(volume->setRegion(source, index, count, region));
     }
 
     /*! assign (named) vec2f parameter to an object */

--- a/ospray/api/LocalDevice.h
+++ b/ospray/api/LocalDevice.h
@@ -94,7 +94,7 @@ namespace ospray {
 
       /*! Copy data into the given volume. */
       int setRegion(OSPVolume object, const void *source,
-                            const vec3i &index, const vec3i &count) override;
+                            const vec3i &index, const vec3i &count, const vec3i &region) override;
 
       /*! assign (named) vec2f parameter to an object */
       void setVec2f(OSPObject object,

--- a/ospray/include/ospray/ospray.h
+++ b/ospray/include/ospray/ospray.h
@@ -463,7 +463,11 @@ extern "C" {
                                     const osp::vec3i &regionCoords, 
                                     /*! size of the region that we're writing to; MUST
                                       be the same as the dimensions of source[][][] */
-                                    const osp::vec3i &regionSize);
+                                    const osp::vec3i &regionSize,
+                                    /*! size of the region that the block of data
+                                      occupies*/
+                                    const osp::vec3i &region
+                                    );
 
   /*! add 2-float parameter to given object */
   OSPRAY_INTERFACE void ospSetVec2f(OSPObject _object, const char *id, const osp::vec2f &v);

--- a/ospray/mpi/MPIDevice.cpp
+++ b/ospray/mpi/MPIDevice.cpp
@@ -486,7 +486,8 @@ namespace ospray {
 
     /*! Copy data into the given object. */
     int MPIDevice::setRegion(OSPVolume _volume, const void *source,
-                             const vec3i &index, const vec3i &count)
+                             const vec3i &index, const vec3i &count,
+                             const vec3i &region)
     {
       Assert(_volume);
       Assert(source);
@@ -507,6 +508,7 @@ namespace ospray {
       cmd.send(index);
       cmd.send(count);
       cmd.send(size);
+      cmd.send(region);
       cmd.send(source,size);
       cmd.flush();
 

--- a/ospray/mpi/MPIDevice.h
+++ b/ospray/mpi/MPIDevice.h
@@ -106,7 +106,8 @@ namespace ospray {
 
       /*! Copy data into the given volume. */
       int setRegion(OSPVolume object, const void *source,
-                            const vec3i &index, const vec3i &count) override;
+                            const vec3i &index, const vec3i &count,
+                            const vec3i &region) override;
 
       /*! assign (named) string parameter to an object */
       void setString(OSPObject object,

--- a/ospray/mpi/worker.cpp
+++ b/ospray/mpi/worker.cpp
@@ -639,6 +639,7 @@ namespace ospray {
           const vec3i index = cmd.get_vec3i();
           const vec3i count = cmd.get_vec3i();
           const size_t size = cmd.get_size_t();
+          const vec3i region = cmd.get_vec3i();
 
           const size_t bcBufferSize = 40*1024*1024;
           static void *bcBuffer = malloc(bcBufferSize);
@@ -649,7 +650,7 @@ namespace ospray {
           Volume *volume = (Volume *)volumeHandle.lookup();
           Assert(volume);
 
-          int success = volume->setRegion(mem, index, count);
+          int success = volume->setRegion(mem, index, count, region);
           // double t1 = getSysTime();
           // static long num = 0;
           // static long bytes = 0;

--- a/ospray/volume/BlockBrickedVolume.cpp
+++ b/ospray/volume/BlockBrickedVolume.cpp
@@ -50,7 +50,7 @@ namespace ospray {
     StructuredVolume::commit();
   }
 
-  int BlockBrickedVolume::setRegion(// points to the first voxel to be copies.
+   int BlockBrickedVolume::setRegion(// points to the first voxel to be copies.
                                     // The voxels at 'source' MUST have
                                     // dimensions 'regionSize', must be
                                     // organized in 3D-array order, and must
@@ -63,7 +63,11 @@ namespace ospray {
                                     // size of the region that we're writing to
                                     // MUST be the same as the dimensions of
                                     // source[][][]
-                                    const vec3i &regionSize)
+                                    const vec3i &regionSize,
+                                    /*! size of the region that the block of data
+                                      occupies*/
+                                    const vec3i &region
+                                    )
   {
     // Create the equivalent ISPC volume container and allocate memory for voxel
     // data.
@@ -105,6 +109,7 @@ namespace ospray {
                                          source,
                                          (const ispc::vec3i &) regionCoords,
                                          (const ispc::vec3i &) regionSize,
+                                         (const ispc::vec3i &) region,
                                          taskIndex);
     });
 

--- a/ospray/volume/BlockBrickedVolume.h
+++ b/ospray/volume/BlockBrickedVolume.h
@@ -39,7 +39,8 @@ namespace ospray {
     //!  indicates success).
     int setRegion(const void *source,
                   const vec3i &index,
-                  const vec3i &count);
+                  const vec3i &count,
+                  const vec3i &region);
 
   private:
 

--- a/ospray/volume/BlockBrickedVolume.ih
+++ b/ospray/volume/BlockBrickedVolume.ih
@@ -48,6 +48,7 @@ struct BlockBrickedVolume {
                             const void *uniform _source,
                             const uniform vec3i &regionSize,
                             const uniform vec3i &targetCoord000,
+                            const uniform vec3i &region,
                             const uniform int taskIndex);
 };
 

--- a/ospray/volume/BlockBrickedVolume.ispc
+++ b/ospray/volume/BlockBrickedVolume.ispc
@@ -172,6 +172,7 @@ void BlockBrickedVolumeUChar_setRegion(BlockBrickedVolume *uniform self,
                                        const void *uniform _source,
                                        const uniform vec3i &targetCoord000,
                                        const uniform vec3i &regionSize,
+                                       const uniform vec3i &region,
                                        const uniform int taskIndex)
 {
   const uint8 *uniform source = (const uint8 *uniform)_source;
@@ -207,6 +208,7 @@ void BlockBrickedVolumeFloat_setRegion(BlockBrickedVolume *uniform self,
                                        const void *uniform _source,
                                        const uniform vec3i &targetCoord000,
                                        const uniform vec3i &regionSize,
+                                       const uniform vec3i &region,
                                        const uniform int taskIndex)
 {
   const float *uniform source = (const float *uniform)_source;
@@ -243,6 +245,7 @@ void BlockBrickedVolumeDouble_setRegion(BlockBrickedVolume *uniform self,
                                         const void *uniform _source,
                                         const uniform vec3i &targetCoord000,
                                         const uniform vec3i &regionSize,
+                                        const uniform vec3i &region,
                                         const uniform int taskIndex)
 {
   const double *uniform source = (const double *uniform)_source;
@@ -387,11 +390,14 @@ BlockBrickedVolume_setRegion(void *uniform _self,
                              /*! size of the region that we're writing to; MUST
                                be the same as the dimensions of source[][][] */
                              const uniform vec3i &regionSize,
+                             /*! size of the region that the block of data
+                               occupies*/
+                             const uniform vec3i &region,
                              const uniform int taskIndex)
 {
   // Cast to the actual Volume subtype.
   BlockBrickedVolume *uniform self = (BlockBrickedVolume *uniform)_self;
-  self->setRegion(self, _source, regionCoords, regionSize, taskIndex);
+  self->setRegion(self, _source, regionCoords, regionSize, region, taskIndex);
 }
 
 export void BlockBrickedVolume_freeVolume(void *uniform _self)

--- a/ospray/volume/DataDistributedBlockedVolume.cpp
+++ b/ospray/volume/DataDistributedBlockedVolume.cpp
@@ -108,7 +108,12 @@ namespace ospray {
       const vec3i &regionCoords,
       /*! size of the region that we're writing to; MUST
         be the same as the dimensions of source[][][] */
-      const vec3i &regionSize)
+      /*! size of the region that the block of data
+        occupies*/
+      const vec3i &regionSize,
+      /*! size of the region that the block of data
+        occupies*/
+      const vec3i &region)
   {
     // Create the equivalent ISPC volume container and allocate memory for voxel
     // data.
@@ -130,7 +135,7 @@ namespace ospray {
       
       ddBlock[i].cppVolume->setRegion(source,
                                       regionCoords-ddBlock[i].domain.lower,
-                                      regionSize);
+                                      regionSize, region);
       ddBlock[i].ispcVolume = ddBlock[i].cppVolume->getIE();
     }
 

--- a/ospray/volume/DataDistributedBlockedVolume.h
+++ b/ospray/volume/DataDistributedBlockedVolume.h
@@ -72,7 +72,8 @@ namespace ospray {
     //! indicates success).
     int setRegion(const void *source,
                   const vec3i &index,
-                  const vec3i &count) override;
+                  const vec3i &count,
+                  const vec3i &region) override;
 
     //NOTE(jda) - a private section needs to be defined to make usage clearer
   //private:

--- a/ospray/volume/DataDistributedBlockedVolume.ih
+++ b/ospray/volume/DataDistributedBlockedVolume.ih
@@ -90,7 +90,8 @@ struct DDBVolume {
   void (*uniform setRegion)(void *uniform _volume, 
                             const void *uniform _source,
                             const uniform vec3i &regionSize, 
-                            const uniform vec3i &targetCoord000);
+                            const uniform vec3i &targetCoord000,
+                            const uniform vec3i &region);
 };
 
 

--- a/ospray/volume/GhostBlockBrickedVolume.cpp
+++ b/ospray/volume/GhostBlockBrickedVolume.cpp
@@ -63,8 +63,11 @@ namespace ospray {
                                     const vec3i &regionCoords, 
                                     /*! size of the region that we're writing to; MUST
                                       be the same as the dimensions of source[][][] */
-                                    const vec3i &regionSize)
-  {
+                                    const vec3i &regionSize,
+                                    /*! size of the region that the block of data
+                                      occupies*/
+                                    const vec3i &region)
+{
     if (g_dbg) PING;
     // Create the equivalent ISPC volume container and allocate memory for voxel data.
     if (ispcEquivalent == NULL) createEquivalentISPC();
@@ -97,7 +100,8 @@ namespace ospray {
     // Copy voxel data into the volume.
     ispc::GGBV_setRegion(ispcEquivalent, source, 
                          (const ispc::vec3i &) regionCoords, 
-                         (const ispc::vec3i &) regionSize);
+                         (const ispc::vec3i &) regionSize,
+                         (const ispc::vec3i &) region);
     return true;
   }
 

--- a/ospray/volume/GhostBlockBrickedVolume.h
+++ b/ospray/volume/GhostBlockBrickedVolume.h
@@ -40,7 +40,8 @@ namespace ospray {
     //! indicates success).
     int setRegion(const void *source,
                   const vec3i &index,
-                  const vec3i &count) override;
+                  const vec3i &count,
+                  const vec3i &region) override;
 
   private:
 

--- a/ospray/volume/GhostBlockBrickedVolume.ih
+++ b/ospray/volume/GhostBlockBrickedVolume.ih
@@ -47,7 +47,8 @@ struct GhostBlockBrickedVolume {
   void (*uniform setRegion)(void *uniform _volume, 
                             const void *uniform _source,
                             const uniform vec3i &regionSize, 
-                            const uniform vec3i &targetCoord000);
+                            const uniform vec3i &targetCoord000,
+                            const uniform vec3i &region);
 };
 
 void GhostBlockBrickedVolume_Constructor(GhostBlockBrickedVolume *uniform volume, 

--- a/ospray/volume/GhostBlockBrickedVolume.ispc
+++ b/ospray/volume/GhostBlockBrickedVolume.ispc
@@ -375,7 +375,8 @@ inline void GGBV_allocateMemory(GGBV *uniform volume)
 task void PBBVUChar_setRegionTask(GGBV *uniform self,
                                   const uint8 *uniform source,
                                   const uniform vec3i &targetCoord000,
-                                  const uniform vec3i &regionSize)
+                                  const uniform vec3i &regionSize,
+                                  const uniform vec3i &region)
 {
   const uniform uint32 region_y = taskIndex % regionSize.y;
   const uniform uint32 region_z = taskIndex / regionSize.y;
@@ -420,7 +421,8 @@ task void PBBVUChar_setRegionTask(GGBV *uniform self,
 task void PBBVFloat_setRegionTask(GGBV *uniform self,
                                   const float *uniform source, 
                                   const uniform vec3i &targetCoord000,
-                                  const uniform vec3i &regionSize)
+                                  const uniform vec3i &regionSize,
+                                  const uniform vec3i &region)
 {
   const uniform uint32 region_y = taskIndex % regionSize.y;
   const uniform uint32 region_z = taskIndex / regionSize.y;
@@ -467,7 +469,8 @@ task void PBBVFloat_setRegionTask(GGBV *uniform self,
 task void PBBVDouble_setRegionTask(GGBV *uniform self,
                                    const double *uniform source, 
                                    const uniform vec3i &targetCoord000,
-                                   const uniform vec3i &regionSize)
+                                   const uniform vec3i &regionSize,
+                                   const uniform vec3i &region)
 {
   const uniform uint32 region_y = taskIndex % regionSize.y;
   const uniform uint32 region_z = taskIndex / regionSize.y;
@@ -500,14 +503,16 @@ task void PBBVDouble_setRegionTask(GGBV *uniform self,
 void GGBVUChar_setRegion(void *uniform _volume, 
                          const void *uniform _source, 
                          const uniform vec3i &targetCoord000,
-                         const uniform vec3i &regionSize)
+                         const uniform vec3i &regionSize,
+                         const uniform vec3i &region)
 {
   // a 'run' is sequence of connected voxels in x direction 
   uniform uint32 numRuns = regionSize.y * regionSize.z;
   launch[numRuns] PBBVUChar_setRegionTask((GGBV*uniform)_volume,
                                           (const uint8*uniform)_source,
                                           targetCoord000,
-                                          regionSize);
+                                          regionSize,
+                                          region);
 }
 
 /*! copy given block of voxels into the volume, where source[0] will
@@ -515,14 +520,16 @@ void GGBVUChar_setRegion(void *uniform _volume,
 void GGBVFloat_setRegion(void *uniform _volume, 
                          const void *uniform _source, 
                          const uniform vec3i &targetCoord000,
-                         const uniform vec3i &regionSize)
+                         const uniform vec3i &regionSize,
+                         const uniform vec3i &region)
 {
   // a 'run' is sequence of connected voxels in x direction 
   uniform uint32 numRuns = regionSize.y * regionSize.z;
   launch[numRuns] PBBVFloat_setRegionTask((GGBV*uniform)_volume,
                                           (const float*uniform)_source,
                                           targetCoord000,
-                                          regionSize);
+                                          regionSize,
+                                          region);
 }
 
 /*! copy given block of voxels into the volume, where source[0] will
@@ -530,14 +537,16 @@ void GGBVFloat_setRegion(void *uniform _volume,
 void GGBVDouble_setRegion(void *uniform _volume, 
                           const void *uniform _source, 
                           const uniform vec3i &targetCoord000,
-                          const uniform vec3i &regionSize)
+                          const uniform vec3i &regionSize,
+                          const uniform vec3i &region)
 {
   // a 'run' is sequence of connected voxels in x direction 
   uniform uint32 numRuns = regionSize.y * regionSize.z;
   launch[numRuns] PBBVDouble_setRegionTask((GGBV*uniform)_volume,
                                            (const double*uniform)_source,
                                            targetCoord000,
-                                           regionSize);
+                                           regionSize,
+                                           region);
 }
 
 /*! perform trilinear interpolation for given sample. unlike old way
@@ -691,11 +700,14 @@ export void GGBV_setRegion(void *uniform _self,
                            const uniform vec3i &regionCoords,
                            /*! size of the region that we're writing to; MUST
                              be the same as the dimensions of source[][][] */
-                           const uniform vec3i &regionSize)
+                           const uniform vec3i &regionSize,
+                           /*! size of the region that the block of data
+                             occupies*/
+                           const uniform vec3i &region)
 {
   // Cast to the actual Volume subtype.
   GGBV *uniform self = (GGBV *uniform)_self;
-  self->setRegion(_self,_source,regionCoords,regionSize);
+  self->setRegion(_self,_source,regionCoords,regionSize,region);
 }
  
 export void GGBV_freeVolume(void *uniform _self)

--- a/ospray/volume/SharedStructuredVolume.cpp
+++ b/ospray/volume/SharedStructuredVolume.cpp
@@ -48,7 +48,8 @@ SharedStructuredVolume::~SharedStructuredVolume()
 
   int SharedStructuredVolume::setRegion(const void *source, 
                                         const vec3i &index, 
-                                        const vec3i &count)
+                                        const vec3i &count,
+                                        const vec3i &region)
   {
     if (getIE() == NULL)
       createEquivalentISPC();
@@ -56,17 +57,20 @@ SharedStructuredVolume::~SharedStructuredVolume()
     case OSP_UCHAR:
       ispc::SharedStructuredVolume_setRegion_uint8(getIE(),source,
                                                    (const ispc::vec3i&)index,
-                                                   (const ispc::vec3i&)count);
+                                                   (const ispc::vec3i&)count,
+                                                   (const ispc::vec3i&)region);
       break;
     case OSP_FLOAT:
       ispc::SharedStructuredVolume_setRegion_float(getIE(),source,
                                                    (const ispc::vec3i&)index,
-                                                   (const ispc::vec3i&)count);
+                                                   (const ispc::vec3i&)count,
+                                                   (const ispc::vec3i&)region);
       break;
     case OSP_DOUBLE:
       ispc::SharedStructuredVolume_setRegion_double(getIE(),source,
                                                    (const ispc::vec3i&)index,
-                                                   (const ispc::vec3i&)count);
+                                                   (const ispc::vec3i&)count,
+                                                   (const ispc::vec3i&)region);
       break;
     default:
       throw std::runtime_error("SharedStructuredVolume::setRegion() not "

--- a/ospray/volume/SharedStructuredVolume.h
+++ b/ospray/volume/SharedStructuredVolume.h
@@ -41,7 +41,7 @@ namespace ospray {
 
     //! Copy voxels into the volume at the given index; not allowed on
     //!  SharedStructuredVolume.
-    int setRegion(const void *source, const vec3i &index, const vec3i &count);
+    int setRegion(const void *source, const vec3i &index, const vec3i &count, const vec3i &region);
 
   private:
 

--- a/ospray/volume/SharedStructuredVolume.ispc
+++ b/ospray/volume/SharedStructuredVolume.ispc
@@ -465,7 +465,8 @@ export void *uniform SharedStructuredVolume_createInstance(void *uniform cppEqui
   (void *uniform _self,                                                 \
    const void *uniform source,                                          \
    const uniform vec3i &index,                                          \
-   const uniform vec3i &count)                                          \
+   const uniform vec3i &count,                                          \
+   const uniform vec3i &region)                                         \
   {                                                                     \
     SharedStructuredVolume *uniform self                                \
       = (SharedStructuredVolume *uniform)_self;                         \

--- a/ospray/volume/StructuredVolume.h
+++ b/ospray/volume/StructuredVolume.h
@@ -54,7 +54,8 @@ namespace ospray {
     /*! \returns 0 on error, any non-zero value indicates success */
     virtual int setRegion(const void *source_pointer,
                           const vec3i &target_index,
-                          const vec3i &source_count) = 0;
+                          const vec3i &source_count,
+                          const vec3i &region) = 0;
 
   protected:
 

--- a/ospray/volume/Volume.h
+++ b/ospray/volume/Volume.h
@@ -85,10 +85,13 @@ namespace ospray {
     virtual void commit() = 0;
 
     //! Copy voxels into the volume at the given index (non-zero return value
-    //!  indicates success).
+    //! indicates success). If the volume is made of uniform blocks, the
+    //! region is equal to count but if volume is composed of non uniform
+    //! blocks may have different regions
     virtual int setRegion(const void *source,
                           const vec3i &index,
-                          const vec3i &count) = 0;
+                          const vec3i &count,
+                          const vec3i &region) = 0;
 
     //! Compute samples at the given world coordinates.
     virtual void computeSamples(float **results,


### PR DESCRIPTION
I am working on an out-of-core volume renderer ( https://github.com/BlueBrain/Livre ) to display different resolutions in different regions of the data. So, I have extended the volume data API slightly to have the resolution of the data as well. It looks like below. For the current API, count = region, where resolution is same with the count but with different resolutions ( count != region ) it will be different. If you have comments, it would be nice to have before I dive deeper.

int ospSetRegion( OSPVolume object, 
                              void *source,
                              const osp::vec3i &index,
                              const osp::vec3i &count,
                              const osp::vec3i &region)