### PR TITLE
Resurrect support for loading the LLNL Richtmyer-Meshkov bob volume

### DIFF
--- a/apps/volumeViewer/loaders/RMVolumeFile.cpp
+++ b/apps/volumeViewer/loaders/RMVolumeFile.cpp
@@ -46,7 +46,8 @@ struct RMLoaderThreads {
     : volume(volume), nextBlockID(0), thread(NULL), nextPinID(0),
       numThreads(numThreads)
   {
-    inFilesDir = fileName;
+    inFilesDir = fileName.substr(0, fileName.rfind('.'));
+    printf("inFilesDir = %s\n", inFilesDir.c_str());
 
     useGZip = (getenv("OSPRAY_RM_NO_GZIP") == NULL);
 
@@ -187,4 +188,41 @@ OSPVolume RMVolumeFile::importVolume(OSPVolume volume)
   return(volume);
 }
 
+OSPObject* RMObjectFile::importObjects(){
+  const char *dpFromEnv = getenv("OSPRAY_DATA_PARALLEL");
+  // Same as OSPObjectFile::importVolume for creating the initial OSPVolume
+  OSPVolume volume = NULL;
+  if (dpFromEnv) {
+    // Create the OSPRay object.
+    std::cout << "#osp.loader: found OSPRAY_DATA_PARALLEL env-var, "
+      << "#osp.loader: trying to use data _parallel_ mode..." << std::endl;
+    osp::vec3i blockDims;
+    int rc = sscanf(dpFromEnv,"%dx%dx%d",&blockDims.x,&blockDims.y,&blockDims.z);
+    if (rc != 3){
+      throw std::runtime_error("could not parse OSPRAY_DATA_PARALLEL env-var. Must be of format <X>x<Y>x<>Z (e.g., '4x4x4'");
+    }
+    volume = ospNewVolume("data_distributed_volume");
+    if (volume == NULL){
+      throw std::runtime_error("#loaders.ospObjectFile: could not create volume ...");
+    }
+    ospSetVec3i(volume,"num_dp_blocks",blockDims);
+  } else {
+    // Create the OSPRay object.
+    std::cout << "#osp.loader: no OSPRAY_DATA_PARALLEL dimensions set, "
+      << "#osp.loader: assuming data replicated mode is desired" << std::endl;
+    std::cout << "#osp.loader: to use data parallel mode, set OSPRAY_DATA_PARALLEL env-var to <X>x<Y>x<Z>" << std::endl;
+    std::cout << "#osp.loader: where X, Y, and Z are the desired _number_ of data parallel blocks" << std::endl;
+    volume = ospNewVolume("block_bricked_volume");
+  }
+  if (volume == NULL){
+    throw std::runtime_error("#loaders.ospObjectFile: could not create volume ...");
+  }
+
+  // We just use the RMVolumeFile loader internally
+  RMVolumeFile vol_file(fileName);
+  OSPObject *objects = new OSPObject[2];
+  objects[0] = vol_file.importVolume(volume);
+  objects[1] = NULL;
+  return objects;
+}
 

--- a/apps/volumeViewer/loaders/RMVolumeFile.h
+++ b/apps/volumeViewer/loaders/RMVolumeFile.h
@@ -18,6 +18,7 @@
 
 #include <string>
 #include "VolumeFile.h"
+#include "ObjectFile.h"
 
 //! \brief specific importer for the LLNL "RM" (Richtmyer-Meshkov) instability files
 /*! Note this exists only for a specific demo */
@@ -35,6 +36,27 @@ public:
 
   //! A string description of this class.
   virtual std::string toString() const { return("ospray_module_loaders::RawVolumeFile"); }
+
+private:
+
+  //! Path to the file containing the volume data.
+  std::string fileName;
+};
+
+//! \brief specific importer for the LLNL "RM" (Richtmyer-Meshkov) instability files
+/*! Note this exists only for a specific demo */
+class RMObjectFile : public ObjectFile {
+public:
+  //! Constructor.
+  RMObjectFile(const std::string &fileName) : fileName(fileName) {}
+
+  //! Destructor.
+  virtual ~RMObjectFile() {}
+  //! Import the object data.
+  virtual OSPObject *importObjects();
+
+  //! A string description of this class.
+  virtual std::string toString() const { return("ospray_module_loaders::RMObjectFile"); }
 
 private:
 

--- a/apps/volumeViewer/loaders/SymbolRegistry.cpp
+++ b/apps/volumeViewer/loaders/SymbolRegistry.cpp
@@ -29,5 +29,7 @@ OSP_REGISTER_VOLUME_FILE(RawVolumeFile, gz);
 // Loader for PLY triangle mesh files.
 OSP_REGISTER_TRIANGLEMESH_FILE(PLYTriangleMeshFile, ply);
 
-// Loader for RAW volume files.
+// Loader for LLNL Richtmyer-Meshkov volume file for demo/testing
 OSP_REGISTER_VOLUME_FILE(RMVolumeFile, bob);
+OSP_REGISTER_OBJECT_FILE(RMObjectFile, bob);
+


### PR DESCRIPTION
I made these changes a bit back on my fork of ospray but didn't get around to opening a pull request. I'm not sure if it'd bork my fork if I pushed these same changes directly or such.

This fixes up the LLNL Richtmyer-Meshkov loader since some changes to the loading API broke support. Since you have to pass a "file extension" for the loader to get called it will handle ".bob" files where the file is actually the directory containing the blocks. So like `./ospVolumeViewer bob123.bob` where bob123 is the directory with the volume data to load will load the volume.