### PR TITLE
Add support for specifying view files on the command line

### DIFF
--- a/apps/common/commandline/CameraParser.h
+++ b/apps/common/commandline/CameraParser.h
@@ -1,4 +1,5 @@
 // ======================================================================== //
+// Copyright 2016 SURVICE Engineering Company                               //
 // Copyright 2009-2016 Intel Corporation                                    //
 //                                                                          //
 // Licensed under the Apache License, Version 2.0 (the "License");          //
@@ -44,6 +45,7 @@ protected:
   ospcommon::vec3f m_eye {-1,  1, -1};
   ospcommon::vec3f m_up  { 1, -1,  1};
   ospcommon::vec3f m_gaze{ 0,  1,  0};
+  float m_fovy{ 60.f };
 
 private:
 

--- a/apps/common/widgets/OSPGlutViewer.cpp
+++ b/apps/common/widgets/OSPGlutViewer.cpp
@@ -1,4 +1,5 @@
 // ======================================================================== //
+// Copyright 2016 SURVICE Engineering Company                               //
 // Copyright 2016 Intel Corporation                                         //
 //                                                                          //
 // Licensed under the Apache License, Version 2.0 (the "License");          //
@@ -287,6 +288,7 @@ void OSPGlutViewer::display()
     m_camera.set("dir", dir);
     m_camera.set("up", viewPort.up);
     m_camera.set("aspect", viewPort.aspect);
+    m_camera.set("fovy", viewPort.openingAngle);
     m_camera.commit();
     viewPort.modified = false;
     m_accumID=0;

--- a/apps/common/widgets/glut3D.cpp
+++ b/apps/common/widgets/glut3D.cpp
@@ -1,4 +1,5 @@
 // ======================================================================== //
+// Copyright 2016 SURVICE Engineering Company                               //
 // Copyright 2009-2016 Intel Corporation                                    //
 //                                                                          //
 // Licensed under the Apache License, Version 2.0 (the "License");          //
@@ -32,7 +33,10 @@
 #  include <sys/times.h>
 #  include <unistd.h> // for usleep
 #endif
+#include <fstream>
 #include <sstream>
+#include <stdexcept>
+#include <string>
 
 namespace ospray {
 
@@ -462,6 +466,54 @@ namespace ospray {
             Glut3DWidget::defaultInitSize.x = atoi(av[i+1]);
             Glut3DWidget::defaultInitSize.y = atoi(av[i+2]);
             removeArgs(*ac,(char **&)av,i,3); --i;
+            continue;
+          }
+          if (arg == "-v" || arg == "--view") {
+            std::ifstream fin(av[i+1]);
+            if (!fin.is_open())
+            {
+              throw std::runtime_error("Failed to open \"" +
+                                       std::string(av[i]) +
+                                       "\" for reading");
+            }
+
+            if (!viewPortFromCmdLine)
+              viewPortFromCmdLine = new Glut3DWidget::ViewPort;
+
+            auto& fx = viewPortFromCmdLine->from.x;
+            auto& fy = viewPortFromCmdLine->from.y;
+            auto& fz = viewPortFromCmdLine->from.z;
+
+            auto& ax = viewPortFromCmdLine->at.x;
+            auto& ay = viewPortFromCmdLine->at.y;
+            auto& az = viewPortFromCmdLine->at.z;
+
+            auto& ux = upVectorFromCmdLine.x;
+            auto& uy = upVectorFromCmdLine.y;
+            auto& uz = upVectorFromCmdLine.z;
+
+            auto& fov = viewPortFromCmdLine->openingAngle;
+
+            auto token = std::string("");
+            while (fin >> token)
+            {
+              if (token == "-vp")
+                fin >> fx >> fy >> fz;
+              else if (token == "-vu")
+                fin >> ux >> uy >> uz;
+              else if (token == "-vi")
+                fin >> ax >> ay >> az;
+              else if (token == "-fv")
+                fin >> fov;
+              else
+              {
+                throw std::runtime_error("Unrecognized token:  \"" + token +
+                                         '\"');
+              }
+            }
+
+            assert(i+1 < *ac);
+            removeArgs(*ac,(char **&)av, i, 2); --i;
             continue;
           }
           if (arg == "-vu") {

--- a/apps/common/widgets/glut3D.cpp
+++ b/apps/common/widgets/glut3D.cpp
@@ -473,7 +473,7 @@ namespace ospray {
             if (!fin.is_open())
             {
               throw std::runtime_error("Failed to open \"" +
-                                       std::string(av[i]) +
+                                       std::string(av[i+1]) +
                                        "\" for reading");
             }
 

--- a/apps/qtViewer/ModelViewer.cpp
+++ b/apps/qtViewer/ModelViewer.cpp
@@ -1,4 +1,5 @@
 // ======================================================================== //
+// Copyright 2016 SURVICE Engineering Company                               //
 // Copyright 2009-2016 Intel Corporation                                    //
 //                                                                          //
 // Licensed under the Apache License, Version 2.0 (the "License");          //
@@ -433,10 +434,12 @@ namespace ospray {
       vec3f from = camera->getFrom();
       vec3f up   = camera->getUp();
       vec3f at   = camera->getAt();
+      float fovy = camera->getFovy();
       std::cout << "#osp:qtv: camera is"
                 << " -vp " << from.x << " " << from.y << " " << from.z
                 << " -vi " << at.x << " " << at.y << " " << at.z
                 << " -vu " << up.x << " " << up.y << " " << up.z
+                << " -fv " << fovy
                 << std::endl;
     }
 

--- a/apps/qtViewer/main.cpp
+++ b/apps/qtViewer/main.cpp
@@ -1,4 +1,5 @@
 // ======================================================================== //
+// Copyright 2016 SURVICE Engineering Company                               //
 // Copyright 2009-2016 Intel Corporation                                    //
 //                                                                          //
 // Licensed under the Apache License, Version 2.0 (the "License");          //
@@ -25,6 +26,9 @@
 // scene graph
 #include "sg/module/Module.h"
 #include "sg/importer/Importer.h"
+
+#include <fstream>
+#include <stdexcept>
 
 namespace ospray {
   namespace viewer {
@@ -95,6 +99,51 @@ namespace ospray {
             sg::loadModule(argv[++argID]);
           } else if (arg == "--renderer") {
             integratorFromCommandLine = argv[++argID];
+          } else if (arg == "-v") {
+            std::ifstream fin(argv[++argID]);
+            if (!fin.is_open())
+            {
+              throw std::runtime_error("Failed to open \"" +
+                                       std::string(argv[argID]) +
+                                       "\" for reading");
+            }
+
+            if (!cameraFromCommandLine) cameraFromCommandLine = new sg::PerspectiveCamera;
+
+            auto x = 0.f;
+            auto y = 0.f;
+            auto z = 0.f;
+
+            auto token = std::string("");
+            while (fin >> token)
+            {
+              if (token == "-vp")
+              {
+                fin >> x >> y >> z;
+                cameraFromCommandLine->setFrom(vec3f(x,y,z));
+              }
+              else if (token == "-vu")
+              {
+                fin >> x >> y >> z;
+                cameraFromCommandLine->setUp(vec3f(x,y,z));
+              }
+              else if (token == "-vi")
+              {
+                fin >> x >> y >> z;
+                upFromCommandLine = vec3f(x, y, z);
+                cameraFromCommandLine->setAt(upFromCommandLine);
+              }
+              else if (token == "-fv")
+              {
+                fin >> x;
+                cameraFromCommandLine->setFovy(x);
+              }
+              else
+              {
+                throw std::runtime_error("Unrecognized token:  \"" + token +
+                                         '\"');
+              }
+            }
           } else if (arg == "-vi") {
             if (!cameraFromCommandLine) cameraFromCommandLine = new sg::PerspectiveCamera;
             assert(argID+3<argc);


### PR DESCRIPTION
Hi folks,

Here are some changes that support specifying view files on the command line for OSPRay apps.  A sample file specifying camera position (-vp), lookat point (-vi), up vector (-vu) and vertical FoV (-fv) for the Fairy Forest scene from Ingo's "UT 3D Animation Repository" is attached.

Thanks for considering these changes.

Christiaan

[fairy_view.txt](https://github.com/ospray/OSPRay/files/386622/fairy_view.txt)
