### PR TITLE
Add support for loading modules from user-specified paths

### DIFF
--- a/ospcommon/library.cpp
+++ b/ospcommon/library.cpp
@@ -1,4 +1,5 @@
 // ======================================================================== //
+// Copyright 2016 SURVICE Engineering Company                               //
 // Copyright 2009-2016 Intel Corporation                                    //
 //                                                                          //
 // Licensed under the Apache License, Version 2.0 (the "License");          //
@@ -29,7 +30,6 @@
 #  include <dlfcn.h>
 #endif
 
-
 namespace ospcommon {
 
   Library::Library(const std::string& name)
@@ -38,7 +38,7 @@ namespace ospcommon {
     FileName    executable = getExecutableFileName();
     std::string path       = ""; // std::string(executable.path()) + "\\";
 
-    auto pos = name.rfind("\\");
+    auto pos = name.rfind(DirSep);
     if (pos != std::string::npos)
       path = name.substr(0, pos+1);
     auto module = name.substr(pos+1);

--- a/ospcommon/library.cpp
+++ b/ospcommon/library.cpp
@@ -34,15 +34,24 @@ namespace ospcommon {
 
   Library::Library(const std::string& name)
   {
+    std::cout << "Library::Library(\"" << name << "\")" << std::endl;
+    FileName    executable = getExecutableFileName();
+    std::string path       = ""; // std::string(executable.path()) + "\\";
+
+    auto pos = name.rfind("\\");
+    if (pos != std::string::npos)
+      path = name.substr(0, pos+1);
+    auto module = name.substr(pos+1);
+
 #ifdef OSPRAY_TARGET_MIC
-    std::string file = name+"_mic";
+    std::string file = module+"_mic";
 #else
-    std::string file = name;
+    std::string file = module;
 #endif
 #ifdef _WIN32
     std::string fullName = file+".dll";
-    FileName executable = getExecutableFileName();
-    lib = LoadLibrary((executable.path() + fullName).c_str());
+    std::cout << "Library::Library - trying " << path + fullName << std::endl;
+    lib = LoadLibrary((path + fullName).c_str());
 #else
 #if defined(__MACOSX__)
     std::string fullName = "lib"+file+".dylib";

--- a/ospcommon/library.cpp
+++ b/ospcommon/library.cpp
@@ -58,7 +58,8 @@ namespace ospcommon {
 #else
     std::string fullName = "lib"+file+".so";
 #endif
-    lib = dlopen(fullName.c_str(), RTLD_NOW);
+    std::cout << "Library::Library - trying " << path + fullName << std::endl;
+    lib = dlopen((path + fullName).c_str(), RTLD_NOW);
     if (!lib) {
       FileName executable = getExecutableFileName();
       lib = dlopen((executable.path() + fullName).c_str(), RTLD_NOW);

--- a/ospcommon/library.cpp
+++ b/ospcommon/library.cpp
@@ -34,9 +34,8 @@ namespace ospcommon {
 
   Library::Library(const std::string& name)
   {
-    std::cout << "Library::Library(\"" << name << "\")" << std::endl;
     FileName    executable = getExecutableFileName();
-    std::string path       = ""; // std::string(executable.path()) + "\\";
+    std::string path       = "";
 
     auto pos = name.rfind(DirSep);
     if (pos != std::string::npos)
@@ -50,7 +49,6 @@ namespace ospcommon {
 #endif
 #ifdef _WIN32
     std::string fullName = file+".dll";
-    std::cout << "Library::Library - trying " << path + fullName << std::endl;
     lib = LoadLibrary((path + fullName).c_str());
 #else
 #if defined(__MACOSX__)
@@ -58,7 +56,6 @@ namespace ospcommon {
 #else
     std::string fullName = "lib"+file+".so";
 #endif
-    std::cout << "Library::Library - trying " << path + fullName << std::endl;
     lib = dlopen((path + fullName).c_str(), RTLD_NOW);
     if (!lib) {
       FileName executable = getExecutableFileName();

--- a/ospcommon/library.h
+++ b/ospcommon/library.h
@@ -1,4 +1,5 @@
 // ======================================================================== //
+// Copyright 2016 SURVICE Engineering Company                               //
 // Copyright 2009-2016 Intel Corporation                                    //
 //                                                                          //
 // Licensed under the Apache License, Version 2.0 (the "License");          //
@@ -18,6 +19,12 @@
 // std
 #include <map>
 #include <string>
+
+#if _WIN32
+#  define DirSep "\\"
+#else
+#  define DirSep "/"
+#endif // _WIN32
 
 namespace ospcommon {
 

--- a/ospray/api/API.cpp
+++ b/ospray/api/API.cpp
@@ -1,4 +1,5 @@
 // ======================================================================== //
+// Copyright 2016 SURVICE Engineering Company                               //
 // Copyright 2009-2016 Intel Corporation                                    //
 //                                                                          //
 // Licensed under the Apache License, Version 2.0 (the "License");          //

--- a/ospray/api/API.cpp
+++ b/ospray/api/API.cpp
@@ -90,6 +90,20 @@ extern "C" void ospInit(int *_ac, const char **_av)
     numThreads = OSPRAY_THREADS.second;
   }
 
+  auto OSPRAY_MODULEPATHS = getEnvVar<std::string>("OSPRAY_MODULEPATHS");
+  if (OSPRAY_MODULEPATHS.first) {
+    auto paths = OSPRAY_MODULEPATHS.second;
+    auto pos   = paths.find(';');
+    while (pos != std::string::npos)
+    {
+      modulePaths.push_back(paths.substr(0, pos));
+      paths = paths.substr(pos+1);
+      pos   = paths.find(';');
+    }
+
+    modulePaths.push_back(paths);
+  }
+
   /* call ospray::init to properly parse common args like
      --osp:verbose, --osp:debug etc */
   ospray::init(_ac,&_av);

--- a/ospray/api/LocalDevice.cpp
+++ b/ospray/api/LocalDevice.cpp
@@ -1,4 +1,5 @@
 // ======================================================================== //
+// Copyright 2016 SURVICE Engineering Company                               //
 // Copyright 2009-2016 Intel Corporation                                    //
 //                                                                          //
 // Licensed under the Apache License, Version 2.0 (the "License");          //
@@ -535,7 +536,7 @@ namespace ospray {
         try
         {
           std::cout << "looking for \"" << name << "\" in \"" << path << "\"" << std::endl;
-          std::string libName = path + "\\ospray_module_" + std::string(name);
+          std::string libName = path + DirSep + "ospray_module_" + std::string(name);
           loadLibrary(libName);
           std::cout << "found in " << path << std::endl;
           std::cout << std::flush;

--- a/ospray/api/LocalDevice.cpp
+++ b/ospray/api/LocalDevice.cpp
@@ -529,8 +529,35 @@ namespace ospray {
     /*! load module */
     int LocalDevice::loadModule(const char *name)
     {
-      std::string libName = "ospray_module_" + std::string(name);
-      loadLibrary(libName);
+      auto found = false;
+      for (auto path : modulePaths)
+      {
+        try
+        {
+          std::cout << "looking for \"" << name << "\" in \"" << path << "\"" << std::endl;
+          std::string libName = path + "\\ospray_module_" + std::string(name);
+          loadLibrary(libName);
+          std::cout << "found in " << path << std::endl;
+          std::cout << std::flush;
+          found = true;
+          break;
+        }
+        catch (...)
+        {
+          // no-op
+         std::cout << "\"" << name << "\" not in \"" << path << "\"" << std::endl;
+         continue;
+        }
+      }
+
+      if (!found)
+      {
+        std::cout << "trying default" << std::endl;
+        std::string libName = "ospray_module_" + std::string(name);
+        loadLibrary(libName);
+        std::cout << "found in default!" << std::endl;
+        std::cout << std::flush;
+      }
 
       std::string initSymName = "ospray_init_module_" + std::string(name);
       void*initSym = getSymbol(initSymName);

--- a/ospray/api/LocalDevice.cpp
+++ b/ospray/api/LocalDevice.cpp
@@ -535,8 +535,10 @@ namespace ospray {
       {
         try
         {
-          std::cout << "looking for \"" << name << "\" in \"" << path << "\"" << std::endl;
-          std::string libName = path + DirSep + "ospray_module_" + std::string(name);
+          std::cout << "looking for \"" << name << "\" in \"" << path << "\""
+                    << std::endl;
+          std::string libName = path + DirSep + "ospray_module_" +
+            std::string(name);
           loadLibrary(libName);
           std::cout << "found in " << path << std::endl;
           std::cout << std::flush;
@@ -546,7 +548,8 @@ namespace ospray {
         catch (...)
         {
           // no-op
-         std::cout << "\"" << name << "\" not in \"" << path << "\"" << std::endl;
+         std::cout << "\"" << name << "\" not in \"" << path << "\""
+                   << std::endl;
          continue;
         }
       }

--- a/ospray/api/LocalDevice.cpp
+++ b/ospray/api/LocalDevice.cpp
@@ -535,32 +535,22 @@ namespace ospray {
       {
         try
         {
-          std::cout << "looking for \"" << name << "\" in \"" << path << "\""
-                    << std::endl;
           std::string libName = path + DirSep + "ospray_module_" +
             std::string(name);
           loadLibrary(libName);
-          std::cout << "found in " << path << std::endl;
-          std::cout << std::flush;
           found = true;
           break;
         }
         catch (...)
         {
           // no-op
-         std::cout << "\"" << name << "\" not in \"" << path << "\""
-                   << std::endl;
-         continue;
         }
       }
 
       if (!found)
       {
-        std::cout << "trying default" << std::endl;
         std::string libName = "ospray_module_" + std::string(name);
         loadLibrary(libName);
-        std::cout << "found in default!" << std::endl;
-        std::cout << std::flush;
       }
 
       std::string initSymName = "ospray_init_module_" + std::string(name);

--- a/ospray/common/OSPCommon.cpp
+++ b/ospray/common/OSPCommon.cpp
@@ -133,8 +133,6 @@ namespace ospray {
             pos   = paths.find(';');
           }
           modulePaths.push_back(paths);
-          for (auto p : modulePaths)
-            std::cout << "module_path = " << p << std::endl;
           removeArgs(ac,av,i, 2);
         } else {
           ++i;

--- a/ospray/common/OSPCommon.cpp
+++ b/ospray/common/OSPCommon.cpp
@@ -48,6 +48,8 @@ namespace ospray {
   int32_t numThreads = -1; //!< for default (==maximum) number of
                            //   OSPRay/Embree threads
 
+  std::vector<std::string> modulePaths;
+
   WarnOnce::WarnOnce(const std::string &s) 
     : s(s) 
   {
@@ -120,6 +122,19 @@ namespace ospray {
         } else if (parm == "--osp:numthreads" || parm == "--osp:num-threads") {
           numThreads = atoi(av[i+1]);
           removeArgs(ac,av,i,2);
+        } else if (parm == "--osp:modulepaths") {
+          auto paths = std::string(av[i+1]);
+          auto pos   = paths.find(';');
+          while (pos != std::string::npos)
+          {
+            modulePaths.push_back(paths.substr(0, pos));
+            paths = paths.substr(pos+1);
+            pos   = paths.find(';');
+          }
+          modulePaths.push_back(paths);
+          for (auto p : modulePaths)
+            std::cout << "module_path = " << p << std::endl;
+          removeArgs(ac,av,i, 2);
         } else {
           ++i;
         }

--- a/ospray/common/OSPCommon.cpp
+++ b/ospray/common/OSPCommon.cpp
@@ -1,4 +1,5 @@
 // ======================================================================== //
+// Copyright 2016 SURVICE Engineering Company                               //
 // Copyright 2009-2016 Intel Corporation                                    //
 //                                                                          //
 // Licensed under the Apache License, Version 2.0 (the "License");          //

--- a/ospray/common/OSPCommon.h
+++ b/ospray/common/OSPCommon.h
@@ -1,4 +1,5 @@
 // ======================================================================== //
+// Copyright 2016 SURVICE Engineering Company                               //
 // Copyright 2009-2016 Intel Corporation                                    //
 //                                                                          //
 // Licensed under the Apache License, Version 2.0 (the "License");          //

--- a/ospray/common/OSPCommon.h
+++ b/ospray/common/OSPCommon.h
@@ -182,6 +182,9 @@ namespace ospray {
       number. (cmdline: --osp:numthreads \<n\>) */
   extern int32 numThreads;
 
+  /*! ';'-separated list of paths to check for ospray modules (cmdline: --osp:modulepaths) */
+  extern std::vector<std::string> modulePaths;
+
   /*! size of OSPDataType */
   OSPRAY_INTERFACE size_t sizeOf(const OSPDataType);
 


### PR DESCRIPTION
Add support for loading modules from user-specified paths, via '--osp:modulepaths' command line arguments or the OSPRAY_MODULEPATHS environment variable.

In either case, the set of paths to try when loading modules is specified as a semi-colon separated list of  paths, e.g.:

  --osp:modulepaths "/home/cgribble/modules;/usr/local/modules"
