### PR TITLE
add support for volume affine transformation

### DIFF
--- a/ospray/common/Ray.ih
+++ b/ospray/common/Ray.ih
@@ -19,6 +19,7 @@
 // ospray 
 #include "../math/vec.ih"
 #include "../math/box.ih"
+#include "../math/AffineSpace.ih"
 
 /*! \brief ospray ray class 
 
@@ -141,4 +142,22 @@ inline void intersectBox(const Ray& ray,
                          float& t1)
 {
   intersectBox(ray, make_box3f(box), t0, t1);
+}
+
+inline void rayTransform(Ray &ray,
+			 const uniform AffineSpace3f &xfm)
+{
+    // numbers in original coordinate
+    const vec3f t0 = ray.org + ray.t0 * ray.dir;
+    const vec3f t  = ray.org + ray.t  * ray.dir;
+    // numbers for transformed ray
+    // -- direction
+    ray.org = xfmPoint (xfm, ray.org);
+    ray.dir = xfmVector(xfm, ray.dir);
+    const vec3f rcp_dir = rcp(ray.dir);
+    // -- starting and ending positions
+    ray.t0 = reduce_max((xfmPoint(xfm, t0) - ray.org) * rcp_dir);
+    ray.t  = reduce_min((xfmPoint(xfm,  t) - ray.org) * rcp_dir);
+    // -- Ng
+    ray.Ng = xfmVector(transposed(xfm.l), ray.Ng);
 }

--- a/ospray/render/scivis/volumeIntegration.ispc
+++ b/ospray/render/scivis/volumeIntegration.ispc
@@ -102,6 +102,9 @@ vec4f SciVisRenderer_computeVolumeInterval(const SciVisRenderer *uniform rendere
                                            varying Ray &ray, float tBegin,
                                            float tEnd, float maxOpacity, bool isShadowRay, const varying float &rayOffset, const varying vec3i &sampleID, uniform float quality)
 {
+  // ray to model coordinate
+  rayTransform(ray, volume->rcp_xfm);
+  // start computation
   vec3f singleCoordinates;
   float singleMax = -1.f;
   float singleMin = 0.01f;
@@ -252,6 +255,8 @@ vec4f SciVisRenderer_computeVolumeInterval(const SciVisRenderer *uniform rendere
       integrateOverLights(renderer, ray, dg, info, litColor, rayOffset, sampleID, quality*0.5f);
       intervalColor = make_vec4f(litColor,intervalColor.w);
     }
+  // ray back to world coordinate
+  rayTransform(ray, volume->xfm);
   return intervalColor;
 }
 
@@ -277,6 +282,9 @@ SciVisRenderer_intersectVolumes(const uniform SciVisRenderer *uniform renderer,
   for (uniform int32 i=0; i<renderer->super.model->volumeCount; i++) {
     Volume *uniform volume_i = renderer->super.model->volumes[i];
 
+    // ray to model coordinate
+    rayTransform(ray, volume_i->rcp_xfm);
+
     // Intersect volume bounding box.
     float t0, t1;
     intersectBox(ray, volume_i->boundingBox, t0, t1);
@@ -290,6 +298,9 @@ SciVisRenderer_intersectVolumes(const uniform SciVisRenderer *uniform renderer,
       t0 = max(t0, tClip0);
       t1 = min(t1, tClip1);
     }
+
+    // ray back to world coordinate
+    rayTransform(ray, volume_i->xfm);
 
     // Update intersected volume.
     if (t0 < t1 && t0 < volumeRay.t0) {

--- a/ospray/volume/Volume.cpp
+++ b/ospray/volume/Volume.cpp
@@ -133,6 +133,17 @@ namespace ospray {
                                                vec3f(0.f)));
     ispc::Volume_setVolumeClippingBox(ispcEquivalent,
                                       (const ispc::box3f &)volumeClippingBox);
+    
+    // Set affine transformation
+    AffineSpace3f xfm;
+    xfm.l.vx = getParam3f("xfm.l.vx",vec3f(1.f,0.f,0.f));
+    xfm.l.vy = getParam3f("xfm.l.vy",vec3f(0.f,1.f,0.f));
+    xfm.l.vz = getParam3f("xfm.l.vz",vec3f(0.f,0.f,1.f));
+    xfm.p    = getParam3f("xfm.p",   vec3f(0.f,0.f,0.f));
+    AffineSpace3f rcp_xfm = rcp(xfm);
+    ispc::Volume_setAffineTransformations(ispcEquivalent,
+					  (ispc::AffineSpace3f&)xfm, 
+					  (ispc::AffineSpace3f&)rcp_xfm);
   }
 
 } // ::ospray

--- a/ospray/volume/Volume.ih
+++ b/ospray/volume/Volume.ih
@@ -19,6 +19,7 @@
 #include "../common/Ray.ih"
 #include "../transferFunction/TransferFunction.ih"
 #include "../math/box.ih"
+#include "../math/AffineSpace.ih"
 
 // #if EXP_DATA_PARALLEL
 // struct DataParallelInfo {
@@ -77,6 +78,10 @@ struct Volume {
 
   //! Clipping box for the volume (applies to volume rendering only). An empty clipping box is ignored.
   uniform box3f volumeClippingBox;
+
+  //! Affine transformation 
+  AffineSpace3f xfm; //!< instantiation matrix
+  AffineSpace3f rcp_xfm; //!< rcp(instantiation matrix)
 
   //! The value at the given sample location in world coordinates.
   varying float (*uniform computeSample)(void *uniform _self, 

--- a/ospray/volume/Volume.ispc
+++ b/ospray/volume/Volume.ispc
@@ -110,6 +110,15 @@ export void Volume_setVolumeClippingBox(void *uniform _self, const uniform box3f
   self->volumeClippingBox = value;
 }
 
+export void Volume_setAffineTransformations(void *uniform _self, 
+					    const uniform AffineSpace3f &xfm,
+					    const uniform AffineSpace3f &rcp_xfm)
+{
+  uniform Volume *uniform self = (uniform Volume *uniform)_self;
+  self->xfm = xfm;
+  self->rcp_xfm = rcp_xfm;
+}
+
 export void Volume_getBoundingBox(uniform box3f *uniform ret, void *uniform _self)
 {
   uniform Volume *uniform self = (uniform Volume *uniform)_self;


### PR DESCRIPTION
Currently you have to manually set the linear part and the translational part of the affine transformation to the volume.

For example
```
(creating a cubic volume...)
ospSetVec3f(volume, "xfm.l.vx", osp::vec3f{ 4.0f, 1.0f, 0.0f});
ospSetVec3f(volume, "xfm.l.vy", osp::vec3f{-1.0f, 2.0f, 0.0f});
ospSetVec3f(volume, "xfm.l.vz", osp::vec3f{ 0.0f, 0.0f, 1.0f});
ospSetVec3f(volume, "xfm.p",    osp::vec3f{ 0.0f, 0.0f, 0.0f});
```
Then commit this volume

The result looks like

![screenshot](https://user-images.githubusercontent.com/13118582/29054000-96397410-7bb0-11e7-8ff9-a090fd09172a.png)
