### PR TITLE
add detail mpi usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1812,7 +1812,7 @@ OSPRay in MPI mode:
 Enabling the MPI module in your build
 -------------------------------------
 
-To build the MPI module the CMake variable `OSPRAY_MODULE_MPI` must be
+To build the MPI module the CMake variable `OSPRAY_MODULE_MPI=ON` must be
 enabled, which can be done directly on the command line (with `-D...`)
 or through a configuration dialog (`ccmake`, `cmake-gui`), see also
 \[Compiling OSPRay\].


### PR DESCRIPTION
Hi team,

I added '=ON' to understand easily.
Not only this change, Could you update Wiki page of "Running OPSRay viewers with the MPI backend"?
It says that OSPRAY_BUILD_MPI_DEVICE=ON to enable mpi.
I believe latter option cannot enable mpi and it might cause trouble to beginner like me.

Best Regards,
Daiki