### PR TITLE
Make default library loading explicit

### DIFF
--- a/components/ospcommon/common.cpp
+++ b/components/ospcommon/common.cpp
@@ -66,6 +66,11 @@ namespace ospcommon {
     LibraryRepository::getInstance()->add(name);
   }
 
+  void loadDefaultLibrary()
+  {
+    LibraryRepository::getInstance()->addDefaultLibrary();
+  }
+
   void *getSymbol(const std::string& name)
   {
     return LibraryRepository::getInstance()->getSymbol(name);

--- a/components/ospcommon/common.h
+++ b/components/ospcommon/common.h
@@ -87,6 +87,7 @@ namespace ospcommon {
   OSPCOMMON_INTERFACE void removeArgs(int &ac, const char **&av,
                                       int where, int howMany);
   OSPCOMMON_INTERFACE void loadLibrary(const std::string &name);
+  OSPCOMMON_INTERFACE void loadDefaultLibrary();
   OSPCOMMON_INTERFACE void *getSymbol(const std::string &name);
 
 #ifdef _WIN32

--- a/components/ospcommon/library.cpp
+++ b/components/ospcommon/library.cpp
@@ -108,7 +108,7 @@ namespace ospcommon {
     return sym;
   }
 
-  LibraryRepository::LibraryRepository()
+  void LibraryRepository::addDefaultLibrary()
   {
     // already populate the repo with "virtual" libs, representing the default OSPRay core lib
 #ifdef _WIN32
@@ -132,5 +132,9 @@ namespace ospcommon {
 #else
     repo["ospray"] = new Library(RTLD_DEFAULT);
 #endif
+  }
+
+  LibraryRepository::LibraryRepository()
+  {
   }
 }

--- a/components/ospcommon/library.h
+++ b/components/ospcommon/library.h
@@ -47,6 +47,9 @@ namespace ospcommon {
       /* returns address of a symbol from any library in the repo */
       void* getSymbol(const std::string& sym) const;
 
+      /* add the default library to the repo */
+      void addDefaultLibrary();
+
     private:
       static LibraryRepository* instance;
       LibraryRepository();

--- a/ospray/api/API.cpp
+++ b/ospray/api/API.cpp
@@ -225,8 +225,10 @@ OSPRAY_CATCH_BEGIN
   }
 
   // no device created on cmd line, yet, so default to localdevice
-  if (!deviceIsSet())
+  if (!deviceIsSet()) {
+    loadDefaultLibrary();
     currentDevice = new ospray::api::LocalDevice;
+  }
 
   ospray::initFromCommandLine(_ac,&_av);
 


### PR DESCRIPTION
Background is if one wants to use another device from a module which uses the
same names for registered objects, the default ospray library is still
preferred as its name appears first in the symbol lookup. In such scenarios,
the default library shouldn't be even loaded.