### PR TITLE
Changes in Transfer Function Abstraction (Cleaned)

### DIFF
--- a/ospray/render/scivis/volumeIntegration.ispc
+++ b/ospray/render/scivis/volumeIntegration.ispc
@@ -131,18 +131,25 @@ vec4f SciVisRenderer_computeVolumeInterval(const SciVisRenderer *uniform
 
   tBegin = tBegin + renderer->volumeEpsilon;
   while (ray.t0 < tEnd && intervalColor.w < maxOpacity) {
+
     // Sample the volume at the hit point in world coordinates.
     const vec3f coordinates = ray.org + ray.t0 * ray.dir;
-    const float sample      = volume->sample(volume, coordinates);
-    if (lastSample == -1.f)
-      lastSample = sample;
-
+    float sample;
     // Look up the color associated with the volume sample.
     // Look up the opacity associated with the volume sample.
     vec3f sampleColor;
     float sampleOpacity;
-    sampleOpacity = volume->transferFunction->getIntegratedOpacityForValue(
-        volume->transferFunction, lastSample, sample);
+
+    if (volume->transferFunction->queryByCoordinate) {
+      sampleOpacity = volume->transferFunction->getOpacityForCoordinate
+	(volume->transferFunction, volume, coordinates);
+    } else {
+      sample = volume->sample(volume, coordinates);
+      if (lastSample == -1.f) { lastSample = sample; }
+      sampleOpacity = volume->transferFunction->getIntegratedOpacityForValue
+	(volume->transferFunction, lastSample, sample);
+    }
+
     if (volume->adaptiveSampling && sampleOpacity > adaptiveBacktrack &&
         ray.t0 > tSkipped)  // adaptive backtack
     {
@@ -168,10 +175,14 @@ vec4f SciVisRenderer_computeVolumeInterval(const SciVisRenderer *uniform
     }
 
     if (!isShadowRay) {
-      sampleColor = volume->transferFunction->getIntegratedColorForValue(
+      if (volume->transferFunction->queryByCoordinate) {
+	sampleColor = volume->transferFunction->getColorForCoordinate
+	  (volume->transferFunction, volume, coordinates);
+      } else {
+	sampleColor = volume->transferFunction->getIntegratedColorForValue(
           volume->transferFunction, lastSample, sample);
-      lastSample = sample;
-
+	lastSample = sample;
+      }
       // Compute gradient shading, if enabled.
       if (volume->gradientShadingEnabled) {
         if (volume->singleShade &&

--- a/ospray/transferFunction/TransferFunction.cpp
+++ b/ospray/transferFunction/TransferFunction.cpp
@@ -26,6 +26,7 @@ namespace ospray {
     vec2f valueRange = getParam2f("valueRange", vec2f(0.0f, 1.0f));
     ispc::TransferFunction_setValueRange(ispcEquivalent,
                                          (const ispc::vec2f &)valueRange);
+    ispc::TransferFunction_setQueryByCoordinate(ispcEquivalent, false);
   }
 
   std::string TransferFunction::toString() const

--- a/ospray/transferFunction/TransferFunction.ih
+++ b/ospray/transferFunction/TransferFunction.ih
@@ -26,11 +26,11 @@ struct TransferFunction {
   vec2f valueRange;
   uniform bool preIntegration;
   uniform bool preIntegrationComputed;
+  uniform bool queryByCoordinate;
 
   //! Interpolated color for the given value.
   varying vec3f (*getColorForValue)(const void *uniform transferFunction, 
                                     varying float value);
-
 
   //! Interpolated color for the given value.
   varying vec3f (*getIntegratedColorForValue)(const void *uniform transferFunction, 
@@ -52,4 +52,15 @@ struct TransferFunction {
   uniform vec2f (*getMinMaxOpacityInRange)(void *uniform transferFunction, 
                                            const uniform vec2f &range);
 
+  // ======================================================================== //
+  //! Interpolated color for the given volume coordinate.
+  varying vec3f (*getColorForCoordinate)(const void *uniform transferFunction,
+					 void *uniform volume,
+					 const varying vec3f coordinate);
+
+  //! Interpolated opacity for the given value.
+  varying float (*getOpacityForCoordinate)(const void *uniform transferFunction,
+					   void *uniform volume,
+					   const varying vec3f coordinate);
+  // ======================================================================== //
 };

--- a/ospray/transferFunction/TransferFunction.ispc
+++ b/ospray/transferFunction/TransferFunction.ispc
@@ -25,3 +25,13 @@ export void TransferFunction_setValueRange(void *uniform pointer,
   // Set the transfer function value range.
   transferFunction->valueRange = value;
 }
+
+export void TransferFunction_setQueryByCoordinate(void *uniform pointer, 
+						  const uniform bool flag) 
+{
+  // Cast to the actual type.
+  uniform TransferFunction *uniform transferFunction = (uniform TransferFunction *uniform) pointer;
+
+  // Set the transfer function value range.
+  transferFunction->queryByCoordinate = flag;
+}


### PR DESCRIPTION
Hi All

Recently I implemented a 2D transfer function widget using OSPRay. The widget takes gradient and scalar as inputs. In order to make the implementation easy, I had to modify some sectionsin TransferFunction class. In particular I allow transfer function to take volume and sample coordinate as inputs, instead of using one scalar value. I think this is a good change, because it then we can easily implement all kinds of multivariate transfer functions using modules.

However I haven't figured out how to handle isosurface.

Qi