### PR TITLE
added sizing fix for orthographic camera

### DIFF
--- a/apps/common/ospapp/OSPApp.cpp
+++ b/apps/common/ospapp/OSPApp.cpp
@@ -587,6 +587,13 @@ namespace ospray {
         camera["apertureRadius"] = apertureRadius.getValue();
       if (camera.hasChild("focusdistance"))
         camera["focusdistance"] = length(pos.getValue() - gaze.getValue());
+
+      // orthographic camera adjustments
+      if (camera.hasChild("height"))
+        camera["height"] = (float)height;
+      if (camera.hasChild("aspect"))
+        camera["aspect"] = width / (float)height;
+
       renderer.verify();
       renderer.commit();
     }


### PR DESCRIPTION
the default orthographic camera in ospApp uses a height and aspect ratio both of 1.0, ignoring the current window size and causing bizarre rendering results.  This small tweak updates the camera height to match the height of the render window and the aspect ratio to be width/height.