### PR TITLE
Fixed affinity CLI parameter.

### DIFF
--- a/ospray/api/Device.cpp
+++ b/ospray/api/Device.cpp
@@ -133,8 +133,10 @@ namespace ospray {
         threadAffinity = OSPRAY_SET_AFFINITY.value() == 0 ? DEAFFINITIZE :
                                                             AFFINITIZE;
       }
-
-      threadAffinity = getParam<int>("setAffinity", threadAffinity);
+      else {
+        threadAffinity = getParam<int>("setAffinity", 0) == 0 ? DEAFFINITIZE : 
+                                                                AFFINITIZE;
+      }
 
       tasking::initTaskingSystem(numThreads);
 


### PR DESCRIPTION
The line threadAffinity = getParam<int>("setAffinity", threadAffinity);
evaluates to 0 or 1 if the parameter exists, which is not a valid enum (AFFINITIZE is 1, DEAFFINITIZE is 2).
It is set as a boolean in OSPCommon.cpp line 119.