### PR TITLE
clearing the sg::Texture2D::textureCache when it is no longer needed

### DIFF
--- a/apps/common/ospapp/OSPApp.cpp
+++ b/apps/common/ospapp/OSPApp.cpp
@@ -662,6 +662,7 @@ usage --> "--generate:type[:parameter1=value,parameter2=value,...]"
         auto &hdri = lights.createChild("hdri", "HDRILight");
         hdri.add(tex);
         renderer.verify(); //TODO: this should not be necessary
+        sg::Texture2D::clearTextureCache();
       }
     }
 

--- a/apps/common/sg/common/Texture2D.cpp
+++ b/apps/common/sg/common/Texture2D.cpp
@@ -100,13 +100,7 @@ namespace ospray {
     {
       FileName fileName = fileNameAbs;
       std::string fileNameBase = fileNameAbs;
-      /* WARNING: this cache means that every texture ever loaded will
-         forever keep at least one refcount - ie, no texture will ever
-         auto-die!!! (to fix this we'd have to add a dedicated
-         'clearTextureCache', or move this caching fucntionality into
-         a CachedTextureLoader objec that each parser creates and
-         destroys) */
-      static std::map<std::string,std::shared_ptr<Texture2D> > textureCache;
+
       if (textureCache.find(fileName.str()) != textureCache.end())
         return textureCache[fileName.str()];
 
@@ -346,7 +340,13 @@ namespace ospray {
       return tex;
     }
 
+    void Texture2D::clearTextureCache()
+    {
+      textureCache.clear();
+    }
+
     OSP_REGISTER_SG_NODE(Texture2D);
 
+    std::map<std::string,std::shared_ptr<Texture2D> > Texture2D::textureCache;
   } // ::ospray::sg
 } // ::ospray

--- a/apps/common/sg/common/Texture2D.h
+++ b/apps/common/sg/common/Texture2D.h
@@ -44,6 +44,7 @@ namespace ospray {
       static std::shared_ptr<Texture2D> load(const FileName &fileName,
                                              const bool preferLinear = false,
                                              const bool nearestFilter = false);
+      static void clearTextureCache();
 
       //! texture size, in pixels
       vec2i size {-1};
@@ -56,6 +57,7 @@ namespace ospray {
       void* data{nullptr};
 
       std::string ospTextureType {"texture2d"};
+      static std::map<std::string,std::shared_ptr<Texture2D> > textureCache;
     };
 
   } // ::ospray::sg

--- a/apps/common/sg/importer/importOBJ.cpp
+++ b/apps/common/sg/importer/importOBJ.cpp
@@ -163,6 +163,8 @@ namespace ospray {
         sgMaterials->push_back(matNodePtr);
       }
 
+      Texture2D::clearTextureCache();
+
       return sgMaterials;
     }
 


### PR DESCRIPTION
Hi,
I am pretty new to OSPRay, so as an exercise I removed the cause of the annoying _#osp: INITIALIZATION ERROR --> OSPRay not yet initialized (most likely this means you tried to call an ospray API function before first calling ospInit())_ messages. These are emitted when trying to release the loaded textures but there's already no device to do that. It just finalizes the intent of commit 60c1a25159ea93ce4072aa7268730ad97325c627 in a similarly minimalistic way.

I am also new to the OSS practice (pull request stuff) and will gladly accept any instructions regarding that.