### PR TITLE
disable compilation of test catch when tests turned off

### DIFF
--- a/components/ospcommon/CMakeLists.txt
+++ b/components/ospcommon/CMakeLists.txt
@@ -197,7 +197,9 @@ else()
 
   ## Build Test Apps ##
 
-  add_library(ospray_test_main STATIC testing/catch_main.cpp)
+  if (OSPRAY_ENABLE_TESTS)
+    add_library(ospray_test_main STATIC testing/catch_main.cpp)
+  endif()
 
   # containers/AlignedVector
   ospray_create_test(test_AlignedVector


### PR DESCRIPTION
a side effect is that this allows compilation under visstudio2013
where noexcept is not available.