### PR TITLE
Fixed memory leak in ospRemoveParam for ospNewData objects.

### DIFF
--- a/ospray/api/ISPCDevice.cpp
+++ b/ospray/api/ISPCDevice.cpp
@@ -212,6 +212,10 @@ namespace ospray {
     void ISPCDevice::removeParam(OSPObject _object, const char *name)
     {
       ManagedObject *object = (ManagedObject *)_object;
+      // ManagedObjects have to be decref before removing them
+      ManagedObject *existing = object->getParam<ManagedObject*>(name, nullptr);
+      if (existing)
+          existing->refDec();
       object->removeParam(name);
     }
 


### PR DESCRIPTION
The specialization of ParametrizedObject::Param::set for
ManagedObjects takes care of calling refInc on a new object
and refDec on a previously existing object. However, the Any member
inside Param doesn't know that it has to call refDec on ManagedObject*,
and so the object is leaked when ospRemoveParam is called.

This fix gets the object and sets it to nullptr before removing.
A better fix would be to use a smart pointer for ManagedObjects in
ParametrizedObject::Param::set.