### PR TITLE
Fix formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2148,7 +2148,9 @@ below).
 
 <figure>
 <img src="https://ospray.github.io/images/diffuse_rooms.png" alt="Comparison of diffuse rooms with 100% reflecting white paint (left) and realistic 80% reflecting white paint (right), which leads to in higher overall contrast. Note that exposure has been adjusted to achieve similar brightness levels." width="80.0%" /><figcaption>Comparison of diffuse rooms with 100% reflecting white paint (left) and realistic 80% reflecting white paint (right), which leads to in higher overall contrast. Note that exposure has been adjusted to achieve similar brightness levels.</figcaption>
-</figure>If present, the color component of [geometries](#geometries) is
+</figure>
+
+If present, the color component of [geometries](#geometries) is
 also used for the diffuse color `Kd` and the alpha component is also
 used for the opacity `d`.
 
@@ -2170,7 +2172,9 @@ or invert its green channel.
 
 <figure>
 <img src="https://ospray.github.io/images/normalmap_frustum.png" alt="Normal map representing an exalted square pyramidal frustum." width="60.0%" /><figcaption>Normal map representing an exalted square pyramidal frustum.</figcaption>
-</figure>All parameters (except `Tf`) can be textured by passing a
+</figure>
+
+All parameters (except `Tf`) can be textured by passing a
 [texture](#texture) handle, prefixed with “`map_`”. The fetched texels
 are multiplied by the respective parameter value. Texturing requires
 [geometries](#geometries) with texture coordinates, e.g. a [triangle
@@ -2182,7 +2186,9 @@ textures support \[texture transformations\].
 
 <figure>
 <img src="https://ospray.github.io/images/material_OBJ.jpg" alt="Rendering of a OBJ material with wood textures." width="60.0%" /><figcaption>Rendering of a OBJ material with wood textures.</figcaption>
-</figure>#### Principled
+</figure>
+
+#### Principled
 
 The Principled material is the most complex material offered by the
 [path tracer](#path-tracer), which is capable of producing a wide
@@ -2390,7 +2396,9 @@ transformations\] are supported as well.
 
 <figure>
 <img src="https://ospray.github.io/images/material_Principled.jpg" alt="Rendering of a Principled coated brushed metal material with textured anisotropic rotation and a dust layer (sheen) on top." width="60.0%" /><figcaption>Rendering of a Principled coated brushed metal material with textured anisotropic rotation and a dust layer (sheen) on top.</figcaption>
-</figure>#### CarPaint
+</figure>
+
+#### CarPaint
 
 The CarPaint material is a specialized version of the Principled
 material for rendering different types of car paints. To create a
@@ -2521,7 +2529,9 @@ transformations\] are supported as well.
 
 <figure>
 <img src="https://ospray.github.io/images/material_CarPaint.jpg" alt="Rendering of a pearlescent CarPaint material." width="60.0%" /><figcaption>Rendering of a pearlescent CarPaint material.</figcaption>
-</figure>#### Metal
+</figure>
+
+#### Metal
 
 The [path tracer](#path-tracer) offers a physical metal, supporting
 changing roughness and realistic color shifts at edges. To create a
@@ -2604,7 +2614,9 @@ supported as well) to create interesting edging effects.
 
 <figure>
 <img src="https://ospray.github.io/images/material_Metal.jpg" alt="Rendering of golden Metal material with textured roughness." width="60.0%" /><figcaption>Rendering of golden Metal material with textured roughness.</figcaption>
-</figure>#### Alloy
+</figure>
+
+#### Alloy
 
 The [path tracer](#path-tracer) offers an alloy material, which behaves
 similar to [Metal](#metal), but allows for more intuitive and flexible
@@ -2631,7 +2643,9 @@ transformations\] are supported as well.
 
 <figure>
 <img src="https://ospray.github.io/images/material_Alloy.jpg" alt="Rendering of a fictional Alloy material with textured color." width="60.0%" /><figcaption>Rendering of a fictional Alloy material with textured color.</figcaption>
-</figure>#### Glass
+</figure>
+
+#### Glass
 
 The [path tracer](#path-tracer) offers a realistic a glass material,
 supporting refraction and volumetric attenuation (i.e. the transparency
@@ -2653,7 +2667,9 @@ trough a glass of thickness `attenuationDistance`.
 
 <figure>
 <img src="https://ospray.github.io/images/material_Glass.jpg" alt="Rendering of a Glass material with orange attenuation." width="60.0%" /><figcaption>Rendering of a Glass material with orange attenuation.</figcaption>
-</figure>#### ThinGlass
+</figure>
+
+#### ThinGlass
 
 The [path tracer](#path-tracer) offers a thin glass material useful for
 objects with just a single surface, most prominently windows. It models
@@ -2688,7 +2704,9 @@ attenuation and thus the material appearance.
 <img src="https://ospray.github.io/images/material_ThinGlass.jpg" alt="Rendering of a ThinGlass material with red attenuation." width="60.0%" /><figcaption>Rendering of a ThinGlass material with red attenuation.</figcaption>
 </figure><figure>
 <img src="https://ospray.github.io/images/ColoredWindow.jpg" alt="Example image of a colored window made with textured attenuation of the ThinGlass material." width="60.0%" /><figcaption>Example image of a colored window made with textured attenuation of the ThinGlass material.</figcaption>
-</figure>#### MetallicPaint
+</figure>
+
+#### MetallicPaint
 
 The [path tracer](#path-tracer) offers a metallic paint material,
 consisting of a base coat with optional flakes and a clear coat. To
@@ -2719,7 +2737,9 @@ flakes are not visible.
 
 <figure>
 <img src="https://ospray.github.io/images/material_MetallicPaint.jpg" alt="Rendering of a MetallicPaint material." width="60.0%" /><figcaption>Rendering of a MetallicPaint material.</figcaption>
-</figure>#### Luminous
+</figure>
+
+#### Luminous
 
 The [path tracer](#path-tracer) supports the Luminous material which
 emits light uniformly in all directions and which can thus be used to
@@ -2730,7 +2750,9 @@ parameters of lights: [`color` and `intensity`](#lights).
 
 <figure>
 <img src="https://ospray.github.io/images/material_Luminous.jpg" alt="Rendering of a yellow Luminous material." width="60.0%" /><figcaption>Rendering of a yellow Luminous material.</figcaption>
-</figure>### Texture
+</figure>
+
+### Texture
 
 OSPRay currently implements two texture types (`texture2d` and `volume`)
 and is open for extension to other types by applications. More types may
@@ -2941,7 +2963,9 @@ images below.
 <img src="https://ospray.github.io/images/camera_architectual.jpg" alt="Enabling the architectural flag corrects the perspective projection distortion, resulting in parallel vertical edges." width="60.0%" /><figcaption>Enabling the <code>architectural</code> flag corrects the perspective projection distortion, resulting in parallel vertical edges.</figcaption>
 </figure><figure>
 <img src="https://ospray.github.io/images/camera_stereo.jpg" alt="Example 3D stereo image using stereoMode side-by-side." width="90.0%" /><figcaption>Example 3D stereo image using <code>stereoMode</code> side-by-side.</figcaption>
-</figure>#### Orthographic Camera
+</figure>
+
+#### Orthographic Camera
 
 The orthographic camera implements a simple camera with orthographic
 projection, without support for depth of field or motion blur. It is
@@ -2965,7 +2989,9 @@ and `imageEnd`, and both methods can be combined. In any case, the
 
 <figure>
 <img src="https://ospray.github.io/images/camera_orthographic.jpg" alt="Example image created with the orthographic camera." width="60.0%" /><figcaption>Example image created with the orthographic camera.</figcaption>
-</figure>#### Panoramic Camera
+</figure>
+
+#### Panoramic Camera
 
 The panoramic camera implements a simple camera without support for
 motion blur. It captures the complete surrounding with a latitude /
@@ -2976,7 +3002,9 @@ by using the [general parameters](#cameras) understood by all cameras.
 
 <figure>
 <img src="https://ospray.github.io/images/camera_panoramic.jpg" alt="Latitude / longitude map created with the panoramic camera." width="90.0%" /><figcaption>Latitude / longitude map created with the panoramic camera.</figcaption>
-</figure>### Picking
+</figure>
+
+### Picking
 
 To get the world-space position of the geometry (if any) seen at \[0–1\]
 normalized screen-space pixel coordinates `screenPos` use


### PR DESCRIPTION
Add newlines after </figure> tags so that links and subsection titles render correctly.