### PR TITLE
Fix CMake error when OSPRAY_TEST is OFF

### DIFF
--- a/modules/mpi/apps/CMakeLists.txt
+++ b/modules/mpi/apps/CMakeLists.txt
@@ -27,7 +27,9 @@ if (NOT WIN32)# Internal Compiler Error on MSVC12...
     ospray_mpi_common
   )
 
-  target_include_directories(ospRandSphereTest PRIVATE ${CMAKE_SOURCE_DIR})
+  if (TARGET ospRandSphereTest)
+    target_include_directories(ospRandSphereTest PRIVATE ${CMAKE_SOURCE_DIR})
+  endif()
 
   ospray_create_test(ospRandSciVisTest
     ospRandSciVisTest.cpp
@@ -37,7 +39,9 @@ if (NOT WIN32)# Internal Compiler Error on MSVC12...
     ospray_gensv
   )
 
-  target_include_directories(ospRandSciVisTest PRIVATE ${CMAKE_SOURCE_DIR})
+  if (TARGET ospRandSphereTest)
+    target_include_directories(ospRandSciVisTest PRIVATE ${CMAKE_SOURCE_DIR})
+  endif()
 
   ospray_create_test(ospDDLoader-test
     ospDDLoader.cpp


### PR DESCRIPTION
Hi

There is a small problem when building the latest OSPRay devel without `OSPRAT_TEST`. So without `OSPRAY_TEST`, targets like `ospRandSphereTest` will not exist so we cannot call `target_link...`

I provided a quick fix ...

Qi