### PR TITLE
fixes a compilation error on cray with icc

### DIFF
--- a/ospray/fb/LocalFB.ispc
+++ b/ospray/fb/LocalFB.ispc
@@ -164,12 +164,15 @@ export uniform float LocalFrameBuffer_accumulateTile(void *uniform _fb,
 export void LocalFrameBuffer_accumulateAuxTile(void *uniform _fb
     , const uniform Tile &tile
     , uniform vec3f *uniform aux
-    , const varying float * uniform ax
-    , const varying float * uniform ay
-    , const varying float * uniform az
+    , const void * uniform _ax
+    , const void * uniform _ay
+    , const void * uniform _az
     )
 {
   uniform LocalFB *uniform fb  = (uniform LocalFB *uniform)_fb;
+  const varying float * uniform ax = (const varying float * uniform) _ax;
+  const varying float * uniform ay = (const varying float * uniform) _ay;
+  const varying float * uniform az = (const varying float * uniform) _az;
 
   const uniform float accumID = tile.accumID;
   const uniform float accScale = rcpf(tile.accumID + 1);


### PR DESCRIPTION
the error reads like
"error: cannot convert 'float ' to 'const float ()[8]' for argument '4'
environment was:
icc 18.0.5, ispc 1.9.2, embree 3.2.0, ospray 1.8.4 all within craype 2.5.6