### PR TITLE
fix an occasional crash with ospinit/ospShutdown cycles

### DIFF
--- a/components/ospcommon/common.cpp
+++ b/components/ospcommon/common.cpp
@@ -75,6 +75,14 @@ namespace ospcommon {
   {
     return LibraryRepository::getInstance()->getSymbol(name);
   }
+  std::string getSymbolsLibrary(const std::string& name)
+  {
+    return LibraryRepository::getInstance()->getSymbolsLibrary(name);
+  }
+  void *getLibrary(const std::string& name)
+  {
+    return LibraryRepository::getInstance()->getLibrary(name);
+  }
 
 } // ::ospcommon
 

--- a/components/ospcommon/common.h
+++ b/components/ospcommon/common.h
@@ -89,6 +89,8 @@ namespace ospcommon {
   OSPCOMMON_INTERFACE void loadLibrary(const std::string &name, bool anchor = true);
   OSPCOMMON_INTERFACE void loadDefaultLibrary();
   OSPCOMMON_INTERFACE void *getSymbol(const std::string &name);
+  OSPCOMMON_INTERFACE std::string getSymbolsLibrary(const std::string &name);
+  OSPCOMMON_INTERFACE void *getLibrary(const std::string &name);
 
 #ifdef _WIN32
 #  define osp_snprintf sprintf_s

--- a/components/ospcommon/library.cpp
+++ b/components/ospcommon/library.cpp
@@ -164,6 +164,7 @@ namespace ospcommon {
   {
     for (auto &l : repo)
       delete l.second;
+    repo.clear();
   }
 
   void LibraryRepository::add(const std::string &name, bool anchor)
@@ -181,6 +182,20 @@ namespace ospcommon {
       sym = lib->second->getSymbol(name);
 
     return sym;
+  }
+  std::string LibraryRepository::getSymbolsLibrary(const std::string &name) const
+  {
+    void *sym = nullptr;
+    std::string rlib = "";
+    for (auto lib = repo.cbegin(); sym == nullptr && lib != repo.end(); ++lib)
+    {
+      sym = lib->second->getSymbol(name);
+      rlib = lib->first;
+    }
+
+    if (sym)
+      return rlib;
+    return "";
   }
 
   void LibraryRepository::addDefaultLibrary()
@@ -213,6 +228,13 @@ namespace ospcommon {
   bool LibraryRepository::libraryExists(const std::string &name) const
   {
     return repo.find(name) != repo.end();
+  }
+  void* LibraryRepository::getLibrary(const std::string &name) const
+  {
+    auto lib = repo.find(name);
+    if (lib != repo.end())
+      return lib->second;
+    return nullptr;
   }
 
 }  // namespace ospcommon

--- a/components/ospcommon/library.h
+++ b/components/ospcommon/library.h
@@ -14,6 +14,8 @@
 // limitations under the License.                                           //
 // ======================================================================== //
 
+#pragma once
+
 #include "common.h"
 // std
 #include <map>
@@ -54,10 +56,14 @@ namespace ospcommon {
       /* returns address of a symbol from any library in the repo */
       void* getSymbol(const std::string& sym) const;
 
+      /* returns name of a library in the repo that holds a symbol */
+      std::string getSymbolsLibrary(const std::string& sym) const;
+
       /* add the default library to the repo */
       void addDefaultLibrary();
 
       bool libraryExists(const std::string &name) const;
+      void* getLibrary(const std::string &name) const;
 
     private:
       static std::unique_ptr<LibraryRepository> instance;

--- a/ospray/api/objectFactory.h
+++ b/ospray/api/objectFactory.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "../common/OSPCommon.h"
+#include "ospcommon/library.h"
 
 #include <map>
 
@@ -31,10 +32,15 @@ namespace ospray {
 
     // Function pointers corresponding to each subtype.
     static std::map<std::string, creationFunctionPointer> symbolRegistry;
+    static std::map<std::string, std::string> symbolsLibRegistry;
+    static std::map<std::string, void* > libRegistry;
     const auto type_string = stringForType(OSP_TYPE);
+    const auto symsLib = symbolsLibRegistry[type];
 
     // Find the creation function for the subtype if not already known.
-    if (symbolRegistry.count(type) == 0) {
+    if (symbolRegistry.count(type) == 0 ||
+	libRegistry[symsLib] != getLibrary(symsLib)) {
+
       postStatusMsg(2) << "#ospray: trying to look up "
                        << type_string << " type '" << type
                        << "' for the first time";
@@ -46,6 +52,10 @@ namespace ospray {
       // Look for the named function.
       symbolRegistry[type] =
           (creationFunctionPointer)getSymbol(creationFunctionName);
+      symbolsLibRegistry[type] =
+          getSymbolsLibrary(creationFunctionName);
+      libRegistry[symbolsLibRegistry[type]] =
+          getLibrary(symbolsLibRegistry[type]);
 
       // The named function may not be found if the requested subtype is not
       // known.


### PR DESCRIPTION
the objectfactory's internal cache of creationfunctionpointers
gets stale when a library is dlunloaded. This change fixes that
by checking if the the library is still valid and if not
making a new cache entry for it.

fixes: https://github.com/ospray/ospray/issues/338