### PR TITLE
Fixing conflicting type definitions of uint8/16/32/64

### DIFF
--- a/ospray/common/OSPCommon.ih
+++ b/ospray/common/OSPCommon.ih
@@ -20,10 +20,12 @@
 
 #include "OSPConfig.h"
 
+#ifndef ISPC_UINT_IS_DEFINED
 typedef unsigned int64 uint64;
 typedef unsigned int32 uint32;
 typedef unsigned int16 uint16;
 typedef unsigned int8  uint8;
+#endif
 
 #define LOG(x)
 


### PR DESCRIPTION
ISPC trunk defines uint8/16/32/64. To make it work for all versions there's a feature test ISPC_UINT_IS_DEFINED.

Please let me know if this fix is needed for master branch or any of released versions.