### PR TITLE
Make OSPray Curves use the Embree format for the tangent buffer

### DIFF
--- a/ospray/geometry/Curves.cpp
+++ b/ospray/geometry/Curves.cpp
@@ -125,8 +125,8 @@ namespace ospray {
 
     if (normalData && normalData->type != OSP_FLOAT3)
       throw std::runtime_error("curves 'normal' array must be type OSP_FLOAT3");
-    if (tangentData && tangentData->type != OSP_FLOAT3)
-      throw std::runtime_error("curves 'tangent' array must be type OSP_FLOAT3");
+    if (tangentData && tangentData->type != OSP_FLOAT4)
+      throw std::runtime_error("curves 'tangent' array must be type OSP_FLOAT4");
 
     postStatusMsg(2) << "#osp: creating curves geometry, "
                      << "#verts=" << numVertices << ", "
@@ -156,7 +156,7 @@ namespace ospray {
                      indexData->numItems,
                      normalData ? (const ispc::vec3f*)normalData->data : nullptr,
                      normalData ? normalData->numItems : 0,
-                     tangentData ? (const ispc::vec3f*)tangentData->data : nullptr,
+                     tangentData ? (const ispc::vec4f*)tangentData->data : nullptr,
                      tangentData ? tangentData->numItems : 0);
   }
 

--- a/ospray/geometry/Curves.ispc
+++ b/ospray/geometry/Curves.ispc
@@ -59,7 +59,7 @@ Curves_set(void           *uniform _self,
            int32           uniform numSegments,
            const uniform vec3f *uniform normalCurve,
            int32           uniform numNormals,
-           const uniform vec3f *uniform tangentCurve,
+           const uniform vec4f *uniform tangentCurve,
            int32           uniform numTangents)
 {
   Curves *uniform self = (Curves *uniform)_self;
@@ -75,8 +75,8 @@ Curves_set(void           *uniform _self,
     rtcSetSharedGeometryBuffer(geom, RTC_BUFFER_TYPE_NORMAL, 0, RTC_FORMAT_FLOAT3,
                                normalCurve, 0, sizeof(uniform vec3f), numNormals);
   if (tangentCurve)
-    rtcSetSharedGeometryBuffer(geom, RTC_BUFFER_TYPE_TANGENT, 0, RTC_FORMAT_FLOAT3,
-                               tangentCurve, 0, sizeof(uniform vec3f), numTangents);
+    rtcSetSharedGeometryBuffer(geom, RTC_BUFFER_TYPE_TANGENT, 0, RTC_FORMAT_FLOAT4,
+                               tangentCurve, 0, sizeof(uniform vec4f), numTangents);
   uniform uint32 geomID = rtcAttachGeometry(model->embreeSceneHandle, geom);
   rtcCommitGeometry(geom);
   rtcReleaseGeometry(geom);


### PR DESCRIPTION
For curve geometry with Hermite basis Embree requires the tangent buffer
in vecf4 format.