### PR TITLE
Fix GCC11 Compile Error in benchmark_register.h

### DIFF
--- a/apps/common/external/benchmark/src/benchmark_register.h
+++ b/apps/common/external/benchmark/src/benchmark_register.h
@@ -2,6 +2,7 @@
 #define BENCHMARK_REGISTER_H
 
 #include <vector>
+#include <limits>
 
 #include "check.h"
 


### PR DESCRIPTION
Fix GCC11 compilation error (Issue #485)  to missing header "limits" in benchmark_register.h

Compiling ospray (Version 2.5, 2.6 and master) with gcc 11.1.0 leads to compilation error:

> `ospray/apps/common/external/benchmark/src/benchmark_register.h:22:30: error: 'numeric_limits' is not a member of 'std'
>     22 |       static const T kmax = std::numeric_limits<T>::max();`

This fix adds the required header <limits> to benchmark_register.h