### PR TITLE
Fix build with gcc-11 on Linux

### DIFF
--- a/modules/mpi/ospray/common/DistributedWorld.cpp
+++ b/modules/mpi/ospray/common/DistributedWorld.cpp
@@ -196,7 +196,7 @@ void DistributedWorld::exchangeRegions()
     }
   }
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(__linux__)
   // TODO WILL: Remove this eventually? It may be useful for users to debug
   // their code when setting regions. Maybe fix build on Apple? Why did
   // it fail to compile?


### PR DESCRIPTION
Build fails with `gcc 11.2.0` toolchain on Linux:

```c++
[...]/modules/mpi/ospray/common/DistributedWorld.cpp:209:48: error: invalid operands to binary expression ('ospray::StatusMsgStream' and 'const ospray::mpi::Region')
          postStatusMsg(OSP_LOG_DEBUG) << "\t" << b << ",";
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~
[...]gcc-11/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../include/c++/11.2.0/system_error:263:5: note: candidate function template not viable: no known conversion from 'const ospray::mpi::Region' to 'const std::error_code' for 2nd argument
    operator<<(basic_ostream<_CharT, _Traits>& __os, const error_code& __e)
    ^
[...]gcc-11/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../include/c++/11.2.0/ostream:511:5: note: candidate function template not viable: no known conversion from 'const ospray::mpi::Region' to 'char' for 2nd argument
    operator<<(basic_ostream<_CharT, _Traits>& __out, char __c)
    ^
[...]

2 warnings and 1 error generated.
```