### PR TITLE
Use `@loader_path` instead of `@executable_path` on macOS

### DIFF
--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -7,7 +7,7 @@ if (OSPRAY_ZIP_MODE)
   set(CMAKE_SKIP_INSTALL_RPATH OFF)
   if (APPLE)
     set(CMAKE_MACOSX_RPATH ON)
-    set(CMAKE_INSTALL_RPATH "@executable_path/" "@executable_path/../${CMAKE_INSTALL_LIBDIR}")
+    set(CMAKE_INSTALL_RPATH "@loader_path/" "@loader_path/../${CMAKE_INSTALL_LIBDIR}")
   else()
     set(CMAKE_INSTALL_RPATH "\$ORIGIN:\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
     # on per target basis:


### PR DESCRIPTION
`@executable_path` resolves to the directory of "the main executable for
the process" while `@loader_path` is the directory of "the mach-o binary
which contains the load command using @loader_path" (see `man dyld`).

This means that using `@executable_path` constrains where I can put
binaries that link to `libospray` if I need `RPATH` to resolve
correctly. In particular, if I install `libospray` into (say)
`/usr/local/lib`, the linker resolves `RPATH` references correctly only
if my linked executable is in `/usr/local/*`.

On the other hand, using `@loader_path` constrains only the
location of the libraries that `libospray` depends on, and my linked
executable can be anywhere in the file system.