### PR TITLE
Install CPU module root directory headers

### DIFF
--- a/modules/cpu/CMakeLists.txt
+++ b/modules/cpu/CMakeLists.txt
@@ -645,6 +645,21 @@ foreach(dir ${SUBDIRS})
   )
 endforeach()
 
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ospray/SDK/modules/cpu/
+  COMPONENT devel
+  FILES_MATCHING
+  PATTERN *.h
+  PATTERN *.ih
+  )
+  
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ospray/SDK/modules/cpu/
+  COMPONENT devel
+  FILES_MATCHING
+  PATTERN *_ispc.h
+  )
+
 ##############################################################
 # Additional interface targets
 ##############################################################


### PR DESCRIPTION
CPU module root directory headers are not installed along the rest of the SDK.
When implementing a custom type (for example, a Camera), the compilation will fail since `Camera.h` includes `ISPCDeviceObject.h`